### PR TITLE
fix: user list action

### DIFF
--- a/js/users-management.js
+++ b/js/users-management.js
@@ -1,6 +1,5 @@
 $(document).ready(function() {
-	sendEmail = function(event) {
-		var userId = event.target.closest('div[data-id]').dataset.id;
+	sendEmail = function(event, user) {
 		var button = event.target.parentElement;
 		var icon = button.querySelector('.icon-mail');
 
@@ -8,7 +7,7 @@ $(document).ready(function() {
 			button.disabled = true
 			$(icon).addClass('icon-loading-small');
 
-			$.post(OC.linkToOCS('apps/preferred_providers/api/v1', 2)+ 'reactivate', {userId: userId}, function(response) {
+			$.post(OC.linkToOCS('apps/preferred_providers/api/v1', 2)+ 'reactivate', {userId: user.id}, function(response) {
 				OC.Notification.showTemporary(t('preferred_providers', 'User enabled and verification email sent!'))
 				$(icon).removeClass('icon-loading-small');
 				button.disabled = false
@@ -31,7 +30,7 @@ $(document).ready(function() {
 			}
 			setTimeout(function() {registerFunction(delay)}, delay);
 		} else {
-			OCA.Settings.UserList.registerAction('resend_email icon-mail', t('preferred_providers', 'Resend verification email and enable'), sendEmail)
+			OCA.Settings.UserList.registerAction('resend_email icon-mail', t('preferred_providers', 'Resend verification email and enable'), sendEmail, (user) => !user.enabled && user.email)
 		}
 	};
 	registerFunction(0);


### PR DESCRIPTION
This PR fixes two things about the action in the user management list:

1. The user id can not be extracted on modern version of Nextcloud causing the action to fail.
2. The action should only be shown if a user is disabled and has an email address.