### PR TITLE
feat(reactivation): add self-service account reactivation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>Preferred Providers</name>
     <summary>Allow Nextcloud to request user accounts</summary>
     <description><![CDATA[Registration handling app for Nextcloud partners only]]></description>
-    <version>1.19.0-dev.0</version>
+    <version>1.20.0-dev.0</version>
     <licence>agpl</licence>
     <author>John Molakvoæ</author>
     <namespace>Preferred_Providers</namespace>
@@ -17,6 +17,11 @@
         <job>OCA\Preferred_Providers\BackgroundJob\NotifyUnsetPassword</job>
         <job>OCA\Preferred_Providers\BackgroundJob\ExpireUnverifiedAccounts</job>
     </background-jobs>
+    <repair-steps>
+        <post-migration>
+            <step>OCA\Preferred_Providers\Migration\BackfillPpDisabled</step>
+        </post-migration>
+    </repair-steps>
     <settings>
         <admin>OCA\Preferred_Providers\Settings\Admin</admin>
         <admin-section>OCA\Preferred_Providers\Settings\Section</admin-section>

--- a/lib/Controller/ReactivateController.php
+++ b/lib/Controller/ReactivateController.php
@@ -1,32 +1,20 @@
 <?php
 
 declare(strict_types=1);
+
 /**
- * @copyright Copyright (c) 2024 Seyed Masih Sajadi <smasihsajadi@gmail.com>
- *
- * @author Seyed Masih Sajadi <smasihsajadi@gmail.com>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2024 Seyed Masih Sajadi <smasihsajadi@gmail.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\Preferred_Providers\Controller;
 
 use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
@@ -36,51 +24,37 @@ use Psr\Log\LoggerInterface;
 
 class ReactivateController extends Controller {
 
-	/** @var string */
-	protected $appName;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var IUserManager */
-	private $userManager;
-
-	/** @var ITimeFactory */
-	private $timeFactory;
-
-	/** @var VerifyMailHelper */
-	private $verifyMailHelper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
-		IConfig $config,
-		IUserManager $userManager,
-		ITimeFactory $timeFactory,
-		VerifyMailHelper $verifyMailHelper,
-		LoggerInterface $logger) {
+		private readonly IConfig $config,
+		private readonly IUserManager $userManager,
+		private readonly ITimeFactory $timeFactory,
+		private readonly VerifyMailHelper $verifyMailHelper,
+		private readonly LoggerInterface $logger,
+	) {
 		parent::__construct($appName, $request);
-		$this->appName = $appName;
-		$this->config = $config;
-		$this->userManager = $userManager;
-		$this->timeFactory = $timeFactory;
-		$this->verifyMailHelper = $verifyMailHelper;
-		$this->logger = $logger;
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 * @PublicPage
+	 * Render the self-service reactivation form.
 	 */
+	#[NoCSRFRequired]
+	#[PublicPage]
+	#[FrontpageRoute(verb: 'GET', url: '/reactivate')]
 	public function showForm(): TemplateResponse {
 		return new TemplateResponse($this->appName, 'reactivate-public', ['status' => 'form'], 'guest');
 	}
 
 	/**
-	 * @PublicPage
+	 * Re-enable an account that this app auto-disabled and send a fresh
+	 * verification mail. The response is identical whether or not the address
+	 * matched an eligible account, to prevent account enumeration.
 	 */
+	#[NoCSRFRequired]
+	#[PublicPage]
+	#[AnonRateLimit(limit: 3, period: 60)]
+	#[FrontpageRoute(verb: 'POST', url: '/reactivate')]
 	public function requestReactivation(string $email = ''): TemplateResponse {
 		$user = $this->userManager->get($email);
 

--- a/lib/Controller/ReactivateController.php
+++ b/lib/Controller/ReactivateController.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2024 Seyed Masih Sajadi <smasihsajadi@gmail.com>
+ *
+ * @author Seyed Masih Sajadi <smasihsajadi@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Preferred_Providers\Controller;
+
+use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+
+class ReactivateController extends Controller {
+
+	/** @var string */
+	protected $appName;
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	/** @var VerifyMailHelper */
+	private $verifyMailHelper;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(string $appName,
+		IRequest $request,
+		IConfig $config,
+		IUserManager $userManager,
+		ITimeFactory $timeFactory,
+		VerifyMailHelper $verifyMailHelper,
+		LoggerInterface $logger) {
+		parent::__construct($appName, $request);
+		$this->appName = $appName;
+		$this->config = $config;
+		$this->userManager = $userManager;
+		$this->timeFactory = $timeFactory;
+		$this->verifyMailHelper = $verifyMailHelper;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 */
+	public function showForm(): TemplateResponse {
+		return new TemplateResponse($this->appName, 'reactivate-public', ['status' => 'form'], 'guest');
+	}
+
+	/**
+	 * @PublicPage
+	 */
+	public function requestReactivation(string $email = ''): TemplateResponse {
+		$user = $this->userManager->get($email);
+
+		if ($user !== null && $this->config->getUserValue($email, $this->appName, 'pp_disabled', '') === '1') {
+			$user->setEnabled(true);
+			$this->config->setUserValue(
+				$email,
+				$this->appName,
+				'disable_user_after',
+				(string)($this->timeFactory->getTime() + AccountController::validateEmailDelay)
+			);
+			$this->config->deleteUserValue($email, $this->appName, 'pp_disabled');
+
+			try {
+				$emailTemplate = $this->verifyMailHelper->generateTemplate($user);
+				$this->verifyMailHelper->sendMail($user, $emailTemplate);
+			} catch (\Exception $e) {
+				$this->logger->error("Can't send reactivation mail to $email", ['exception' => $e]);
+			}
+
+			$this->logger->info("User $email requested self-reactivation");
+		}
+
+		// Always return the same response to prevent email enumeration.
+		return new TemplateResponse($this->appName, 'reactivate-public', ['status' => 'sent'], 'guest');
+	}
+}

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -117,6 +117,10 @@ class SettingsController extends OCSController {
 			$user->setEnabled(true);
 		}
 
+		// an admin reactivation supersedes the self-service flow: drop the
+		// auto-disabled flag so it cannot linger and be acted on later
+		$this->config->deleteUserValue($userId, $this->appName, 'pp_disabled');
+
 		try {
 			// send email without the reset password link
 			$emailTemplate = $this->verifyMailHelper->generateTemplate($user);

--- a/lib/Helper/ExpireUserTrait.php
+++ b/lib/Helper/ExpireUserTrait.php
@@ -1,8 +1,10 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2018 John Molakvoæ <skjnldsv@protonmail.com>
+ * SPDX-FileCopyrightText: 2024 Seyed Masih Sajadi <smasihsajadi@gmail.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -27,6 +29,9 @@ trait ExpireUserTrait {
 
 		// disabling
 		$user->setEnabled(false);
+		// flag the account as auto-disabled by this app, so it can be told apart
+		// from admin-disabled accounts and offered self-service reactivation
+		$this->config->setUserValue($userId, $this->appName, 'pp_disabled', '1');
 
 		// removing token to avoid conflict with further manual manipulation of the user
 		$this->config->deleteUserValue($userId, $this->appName, 'disable_user_after');

--- a/lib/Mailer/VerifyMailHelper.php
+++ b/lib/Mailer/VerifyMailHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
  * SPDX-FileCopyrightText: 2017 Lukas Reschke <lukas@statuscode.ch>
+ * SPDX-FileCopyrightText: 2024 Seyed Masih Sajadi <smasihsajadi@gmail.com>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -156,7 +157,11 @@ class VerifyMailHelper {
 		$emailTemplate->setSubject($this->l10n->t('Your %s account has been disabled', [$this->themingDefaults->getName()]));
 		$emailTemplate->addHeader();
 		$emailTemplate->addBodyText($this->l10n->t('Your %s account %s has been disabled because it was not verified in time.', [$this->themingDefaults->getName(), $userId]));
-		$emailTemplate->addBodyText($this->l10n->t('Please contact your provider for further assistance.'));
+		$reactivateLink = $this->urlGenerator->linkToRouteAbsolute($this->appName . '.reactivate.showform');
+		$emailTemplate->addBodyButton(
+			$this->l10n->t('Reactivate your account'),
+			$reactivateLink
+		);
 		$emailTemplate->addFooter();
 		return $emailTemplate;
 	}

--- a/lib/Migration/BackfillPpDisabled.php
+++ b/lib/Migration/BackfillPpDisabled.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Seyed Masih Sajadi <smasihsajadi@gmail.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Migration;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Self-service reactivation only re-enables accounts flagged with `pp_disabled=1`,
+ * a flag introduced together with the feature. Accounts that were auto-disabled
+ * *before* the feature shipped never got the flag and would be stuck.
+ *
+ * This repair step backfills the flag. Rather than scanning every user, it starts
+ * from the small set of accounts that still hold a Preferred Providers token
+ * (`set_password`/`verify_token`) — i.e. accounts this app provisioned and that
+ * never completed verification — and flags the ones that are currently disabled.
+ * That token is a best-effort signal the account was auto-disabled by this app
+ * rather than by an admin. It is idempotent (already-flagged accounts are skipped).
+ *
+ * Cost scales with the number of unverified/pending PP accounts (typically tiny),
+ * not with total user count, and uses only varchar comparisons so it is portable
+ * across sqlite/mysql/pgsql/oracle (no CLOB `configvalue` comparison).
+ */
+class BackfillPpDisabled implements IRepairStep {
+
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly IConfig $config,
+		private readonly IUserManager $userManager,
+	) {
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return 'Backfill pp_disabled flag for accounts auto-disabled before self-service reactivation';
+	}
+
+	#[\Override]
+	public function run(IOutput $output): void {
+		$stamped = 0;
+		foreach ($this->getCandidateUserIds() as $userId) {
+			if ($this->config->getUserValue($userId, Application::APP_ID, 'pp_disabled', '') === '1') {
+				continue;
+			}
+
+			$user = $this->userManager->get($userId);
+			// only accounts that are actually disabled are eligible; a null user is
+			// a stale preferences row for a deleted account
+			if ($user === null || $user->isEnabled()) {
+				continue;
+			}
+
+			$this->config->setUserValue($userId, Application::APP_ID, 'pp_disabled', '1');
+			$stamped++;
+		}
+
+		$output->info(sprintf('Flagged %d previously auto-disabled account(s) for self-service reactivation', $stamped));
+	}
+
+	/**
+	 * User IDs that still carry a leftover Preferred Providers verification token.
+	 *
+	 * @return list<string>
+	 */
+	private function getCandidateUserIds(): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->selectDistinct('userid')
+			->from('preferences')
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter(Application::APP_ID)))
+			->andWhere($qb->expr()->in(
+				'configkey',
+				$qb->createNamedParameter(['set_password', 'verify_token'], IQueryBuilder::PARAM_STR_ARRAY)
+			));
+
+		$result = $qb->executeQuery();
+		$userIds = [];
+		while ($row = $result->fetch()) {
+			$userIds[] = (string)$row['userid'];
+		}
+		$result->closeCursor();
+
+		return $userIds;
+	}
+}

--- a/templates/reactivate-public.php
+++ b/templates/reactivate-public.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author Seyed Masih Sajadi <smasihsajadi@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+?>
+<div class="guest-box login-box">
+<?php if ($_['status'] === 'sent') { ?>
+	<h2><?php p($l->t('Check your email')); ?></h2>
+	<p class="info"><?php p($l->t('If a deactivated account for that address exists, we\'ve sent a new verification link. It expires in 6 hours.')); ?></p>
+<?php } else { ?>
+	<form action="" id="reactivate-form" method="post">
+		<fieldset>
+			<h2><?php p($l->t('Reactivate your account')); ?></h2>
+			<div>
+				<label for="email"><?php p($l->t('Account name or email')); ?></label>
+				<input type="email" name="email" id="email" value="" placeholder="<?php p($l->t('Enter your email address')); ?>" required autofocus />
+			</div>
+			<div id="submit-wrapper">
+				<input class="login primary" type="submit" id="submit" value="<?php p($l->t('Send reactivation email')); ?>" />
+			</div>
+		</fieldset>
+	</form>
+<?php } ?>
+</div>

--- a/templates/reactivate-public.php
+++ b/templates/reactivate-public.php
@@ -1,25 +1,8 @@
 <?php
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2018 John Molakvoæ <skjnldsv@protonmail.com>
- *
- * @author Seyed Masih Sajadi <smasihsajadi@gmail.com>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2024 Seyed Masih Sajadi <smasihsajadi@gmail.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 ?>
 <div class="guest-box login-box">

--- a/tests/Unit/BackgroundJob/ExpireUnverifiedAccountsTest.php
+++ b/tests/Unit/BackgroundJob/ExpireUnverifiedAccountsTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Preferred_Providers\Tests\Unit\BackgroundJob;
 
+use OCA\Preferred_Providers\AppInfo\Application;
 use OCA\Preferred_Providers\BackgroundJob\ExpireUnverifiedAccounts;
 use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -96,6 +97,10 @@ class ExpireUnverifiedAccountsTest extends TestCase {
 
 		$this->config->expects($this->atLeastOnce())
 			->method('deleteUserValue');
+		// the account is flagged as auto-disabled by this app for self-service reactivation
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('alice', Application::APP_ID, 'pp_disabled', '1');
 		$this->mailHelper->method('generateTemplate')
 			->with($user, false, true)
 			->willReturn($this->createMock(\OCP\Mail\IEMailTemplate::class));

--- a/tests/Unit/Controller/ReactivateControllerTest.php
+++ b/tests/Unit/Controller/ReactivateControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Controller;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Controller\ReactivateController;
+use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Mail\IEMailTemplate;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class ReactivateControllerTest extends TestCase {
+	private IConfig&MockObject $config;
+	private IUserManager&MockObject $userManager;
+	private ITimeFactory&MockObject $timeFactory;
+	private VerifyMailHelper&MockObject $verifyMailHelper;
+	private LoggerInterface&MockObject $logger;
+
+	private ReactivateController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->verifyMailHelper = $this->createMock(VerifyMailHelper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new ReactivateController(
+			Application::APP_ID,
+			$this->createMock(IRequest::class),
+			$this->config,
+			$this->userManager,
+			$this->timeFactory,
+			$this->verifyMailHelper,
+			$this->logger,
+		);
+	}
+
+	public function testShowFormRendersForm(): void {
+		$response = $this->controller->showForm();
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('reactivate-public', $response->getTemplateName());
+		$this->assertSame('form', $response->getParams()['status']);
+	}
+
+	public function testRequestReactivationUnknownEmailIsSilent(): void {
+		$this->userManager->method('get')->with('nobody@example.com')->willReturn(null);
+		$this->verifyMailHelper->expects($this->never())->method('sendMail');
+
+		$response = $this->controller->requestReactivation('nobody@example.com');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('sent', $response->getParams()['status']);
+	}
+
+	public function testRequestReactivationSkipsNonPpDisabledAccount(): void {
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->with('admin-disabled@example.com')->willReturn($user);
+		// not flagged as auto-disabled by this app
+		$this->config->method('getUserValue')->willReturn('');
+
+		$user->expects($this->never())->method('setEnabled');
+		$this->verifyMailHelper->expects($this->never())->method('sendMail');
+
+		$response = $this->controller->requestReactivation('admin-disabled@example.com');
+
+		$this->assertSame('sent', $response->getParams()['status']);
+	}
+
+	public function testRequestReactivationReenablesPpDisabledAccount(): void {
+		$email = 'user@example.com';
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->with($email)->willReturn($user);
+		$this->config->method('getUserValue')
+			->with($email, Application::APP_ID, 'pp_disabled', '')
+			->willReturn('1');
+		$this->timeFactory->method('getTime')->willReturn(1000);
+
+		$user->expects($this->once())->method('setEnabled')->with(true);
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with($email, Application::APP_ID, 'disable_user_after', $this->isType('string'));
+		$this->config->expects($this->once())
+			->method('deleteUserValue')
+			->with($email, Application::APP_ID, 'pp_disabled');
+		$this->verifyMailHelper->method('generateTemplate')
+			->with($user)
+			->willReturn($this->createMock(IEMailTemplate::class));
+		$this->verifyMailHelper->expects($this->once())->method('sendMail')->with($user, $this->anything());
+
+		$response = $this->controller->requestReactivation($email);
+
+		$this->assertSame('sent', $response->getParams()['status']);
+	}
+}

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -163,6 +163,11 @@ class SettingsControllerTest extends TestCase {
 		$user->expects($this->never())->method('setEnabled');
 		$this->userManager->method('get')->with('user')->willReturn($user);
 
+		// admin reactivation clears any lingering self-service flag
+		$this->config->expects($this->once())
+			->method('deleteUserValue')
+			->with('user', Application::APP_ID, 'pp_disabled');
+
 		$emailTemplate = $this->createMock(IEMailTemplate::class);
 		$this->verifyMailHelper->expects($this->once())
 			->method('generateTemplate')

--- a/tests/Unit/Migration/BackfillPpDisabledTest.php
+++ b/tests/Unit/Migration/BackfillPpDisabledTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Migration;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Migration\BackfillPpDisabled;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class BackfillPpDisabledTest extends TestCase {
+	private IDBConnection&MockObject $db;
+	private IConfig&MockObject $config;
+	private IUserManager&MockObject $userManager;
+	private BackfillPpDisabled $step;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->step = new BackfillPpDisabled($this->db, $this->config, $this->userManager);
+	}
+
+	public function testGetName(): void {
+		$this->assertIsString($this->step->getName());
+	}
+
+	public function testBackfillsOnlyDisabledUnflaggedAccounts(): void {
+		// candidate users that still hold a PP token
+		$this->stubCandidateUsers(['alice', 'bob', 'carol', 'ghost']);
+
+		// alice: disabled, not yet flagged   -> flagged
+		// bob:   already flagged             -> skipped
+		// carol: still enabled               -> skipped
+		// ghost: deleted (userManager null)  -> skipped
+		$this->config->method('getUserValue')->willReturnCallback(
+			static fn (string $uid, string $app, string $key, string $default = ''): string
+				=> $uid === 'bob' && $key === 'pp_disabled' ? '1' : $default
+		);
+
+		$alice = $this->createMock(IUser::class);
+		$alice->method('isEnabled')->willReturn(false);
+		$carol = $this->createMock(IUser::class);
+		$carol->method('isEnabled')->willReturn(true);
+		$this->userManager->method('get')->willReturnMap([
+			['alice', $alice],
+			['carol', $carol],
+			['ghost', null],
+		]);
+
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('alice', Application::APP_ID, 'pp_disabled', '1');
+
+		$this->step->run($this->createMock(IOutput::class));
+	}
+
+	/**
+	 * @param list<string> $userIds
+	 */
+	private function stubCandidateUsers(array $userIds): void {
+		$rows = array_map(static fn (string $u): array => ['userid' => $u], $userIds);
+
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturnOnConsecutiveCalls(...[...$rows, false]);
+
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('eq')->willReturn('cmp');
+		$expr->method('in')->willReturn('cmp');
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('selectDistinct')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('where')->willReturnSelf();
+		$qb->method('andWhere')->willReturnSelf();
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('createNamedParameter')->willReturn('param');
+		$qb->method('executeQuery')->willReturn($result);
+
+		$this->db->method('getQueryBuilder')->willReturn($qb);
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -50,6 +50,12 @@
       <code><![CDATA[unsetMagicInCookie]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Controller/ReactivateController.php">
+    <MissingDependency>
+      <code><![CDATA[$this->timeFactory]]></code>
+      <code><![CDATA[private]]></code>
+    </MissingDependency>
+  </file>
   <file src="lib/Controller/SettingsController.php">
     <MissingDependency>
       <code><![CDATA[protected]]></code>


### PR DESCRIPTION
Closes #5

Summary

Users whose accounts were auto-disabled for missing the email verification window previously had no recourse other than contacting an admin. This MR adds a fully self-service reactivation flow so users can recover their accounts without support intervention.

What changed

- ExpireUserTrait — stamps a pp_disabled=1 flag when disabling a user, so we can distinguish PP-disabled accounts from admin-disabled ones.
- ReactivateController — new public controller with two endpoints:
  - GET /reactivate — renders the reactivation form.
  - POST /reactivate — re-enables the account, resets the verification deadline, and sends a fresh verification email. Always returns the same response regardless of whether the email matched an account, preventing email enumeration.
- VerifyMailHelper — replaces the static "contact your provider" text in the account-disabled email with a "Reactivate your account" CTA button linking to the new form.
- templates/reactivate-public.php — guest-layout template with two states: the email input form and a post-submission confirmation.
- appinfo/routes.php — registers the two new public routes.

Security notes

- The POST handler deliberately does not distinguish between "email not found" and "account found and reactivated" — the response is always the same to prevent account enumeration.
- Only accounts flagged with pp_disabled=1 (i.e., auto-disabled by this app) can be reactivated through this flow; admin-disabled accounts are unaffected.
- Re-enables the account and resets disable_user_after to the standard verification window before sending the new verification email.