### PR TITLE
Add PHPUnit test suite + CI matrix

### DIFF
--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -1,0 +1,201 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: PHPUnit MySQL
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phpunit-mysql-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest-low
+    outputs:
+      matrix: ${{ steps.versions.outputs.sparse-matrix }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+        with:
+          matrix: '{"mysql-versions": ["8.4"]}'
+
+  changes:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - 'appinfo/**'
+              - 'lib/**'
+              - 'templates/**'
+              - 'tests/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - '.php-cs-fixer.dist.php'
+              - 'composer.json'
+              - 'composer.lock'
+
+  phpunit-mysql:
+    runs-on: ubuntu-latest
+
+    needs: [changes, matrix]
+    if: needs.changes.outputs.src != 'false'
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+
+    name: MySQL ${{ matrix.mysql-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
+
+    services:
+      mysql:
+        image: ghcr.io/nextcloud/continuous-integration-mysql-${{ matrix.mysql-versions }}:latest # zizmor: ignore[unpinned-images]
+        ports:
+          - 4444:3306/tcp
+        env:
+          MYSQL_ROOT_PASSWORD: rootpassword
+        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
+
+    steps:
+      - name: Set app env
+        if: ${{ env.APP_NAME == '' }}
+        run: |
+          # Split and keep last
+          echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+
+      - name: Checkout server
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: true
+          repository: nextcloud/server
+          ref: ${{ matrix.server-versions }}
+
+      - name: Checkout app
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql
+          coverage: none
+          ini-file: development
+          # Temporary workaround for missing pcntl_* in PHP 8.3
+          ini-values: disable_functions=
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable ONLY_FULL_GROUP_BY MySQL option
+        run: |
+          echo "SET GLOBAL sql_mode=(SELECT CONCAT(@@sql_mode,',ONLY_FULL_GROUP_BY'));" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
+          echo 'SELECT @@sql_mode;' | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
+
+      - name: Check composer file existence
+        id: check_composer
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
+        with:
+          files: apps/${{ env.APP_NAME }}/composer.json
+
+      - name: Set up dependencies
+        # Only run if phpunit config file exists
+        if: steps.check_composer.outputs.files_exists == 'true'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer remove nextcloud/ocp --dev --no-scripts
+          composer i
+
+      - name: Set up Nextcloud
+        env:
+          DB_PORT: 4444
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
+          ./occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: Check PHPUnit script is defined
+        id: check_phpunit
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep '^  test:unit ' | wc -l | grep 1
+
+      - name: PHPUnit
+        # Only run if phpunit config file exists
+        if: steps.check_phpunit.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer run test:unit
+
+      - name: Check PHPUnit integration script is defined
+        id: check_integration
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep '^  test:integration ' | wc -l | grep 1
+
+      - name: Run Nextcloud
+        # Only run if phpunit integration config file exists
+        if: steps.check_integration.outcome == 'success'
+        run: php -S localhost:8080 &
+
+      - name: PHPUnit integration
+        # Only run if phpunit integration config file exists
+        if: steps.check_integration.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer run test:integration
+
+      - name: Print logs
+        if: always()
+        run: |
+          cat data/nextcloud.log
+
+      - name: Skipped
+        # Fail the action when neither unit nor integration tests ran
+        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        run: |
+          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          exit 1
+
+  summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest-low
+    needs: [changes, phpunit-mysql]
+
+    if: always()
+
+    name: phpunit-mysql-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-mysql.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -1,0 +1,199 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: PHPUnit PostgreSQL
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phpunit-pgsql-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest-low
+    outputs:
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+
+  changes:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      src: ${{ steps.changes.outputs.src }}
+
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - 'appinfo/**'
+              - 'lib/**'
+              - 'templates/**'
+              - 'tests/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - '.php-cs-fixer.dist.php'
+              - 'composer.json'
+              - 'composer.lock'
+
+  phpunit-pgsql:
+    runs-on: ubuntu-latest
+
+    needs: [changes, matrix]
+    if: needs.changes.outputs.src != 'false'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+
+    name: PostgreSQL PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
+
+    services:
+      postgres:
+        image: ghcr.io/nextcloud/continuous-integration-postgres-16:latest # zizmor: ignore[unpinned-images]
+        ports:
+          - 4444:5432/tcp
+        env:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: rootpassword
+          POSTGRES_DB: nextcloud
+        options: --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
+
+    steps:
+      - name: Set app env
+        if: ${{ env.APP_NAME == '' }}
+        run: |
+          # Split and keep last
+          echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+
+      - name: Checkout server
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: true
+          repository: nextcloud/server
+          ref: ${{ matrix.server-versions }}
+
+      - name: Checkout app
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
+          coverage: none
+          ini-file: development
+          # Temporary workaround for missing pcntl_* in PHP 8.3
+          ini-values: disable_functions=
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check composer file existence
+        id: check_composer
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
+        with:
+          files: apps/${{ env.APP_NAME }}/composer.json
+
+      - name: Set up dependencies
+        # Only run if phpunit config file exists
+        if: steps.check_composer.outputs.files_exists == 'true'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer remove nextcloud/ocp --dev --no-scripts
+          composer i
+
+      - name: Set up Nextcloud
+        env:
+          DB_PORT: 4444
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
+          ./occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: Check PHPUnit script is defined
+        id: check_phpunit
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep '^  test:unit ' | wc -l | grep 1
+
+      - name: PHPUnit
+        # Only run if phpunit config file exists
+        if: steps.check_phpunit.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer run test:unit
+
+      - name: Check PHPUnit integration script is defined
+        id: check_integration
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep '^  test:integration ' | wc -l | grep 1
+
+      - name: Run Nextcloud
+        # Only run if phpunit integration config file exists
+        if: steps.check_integration.outcome == 'success'
+        run: php -S localhost:8080 &
+
+      - name: PHPUnit integration
+        # Only run if phpunit integration config file exists
+        if: steps.check_integration.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer run test:integration
+
+      - name: Print logs
+        if: always()
+        run: |
+          cat data/nextcloud.log
+
+      - name: Skipped
+        # Fail the action when neither unit nor integration tests ran
+        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        run: |
+          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          exit 1
+
+  summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest-low
+    needs: [changes, phpunit-pgsql]
+
+    if: always()
+
+    name: phpunit-pgsql-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-pgsql.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -1,0 +1,188 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: PHPUnit SQLite
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phpunit-sqlite-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest-low
+    outputs:
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+
+  changes:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - 'appinfo/**'
+              - 'lib/**'
+              - 'templates/**'
+              - 'tests/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - '.php-cs-fixer.dist.php'
+              - 'composer.json'
+              - 'composer.lock'
+
+  phpunit-sqlite:
+    runs-on: ubuntu-latest
+
+    needs: [changes, matrix]
+    if: needs.changes.outputs.src != 'false'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+
+    name: SQLite PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
+
+    steps:
+      - name: Set app env
+        if: ${{ env.APP_NAME == '' }}
+        run: |
+          # Split and keep last
+          echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+
+      - name: Checkout server
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: true
+          repository: nextcloud/server
+          ref: ${{ matrix.server-versions }}
+
+      - name: Checkout app
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          coverage: none
+          ini-file: development
+          # Temporary workaround for missing pcntl_* in PHP 8.3
+          ini-values: disable_functions=
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check composer file existence
+        id: check_composer
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
+        with:
+          files: apps/${{ env.APP_NAME }}/composer.json
+
+      - name: Set up dependencies
+        # Only run if phpunit config file exists
+        if: steps.check_composer.outputs.files_exists == 'true'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer remove nextcloud/ocp --dev --no-scripts
+          composer i
+
+      - name: Set up Nextcloud
+        env:
+          DB_PORT: 4444
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
+          ./occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: Check PHPUnit script is defined
+        id: check_phpunit
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep '^  test:unit ' | wc -l | grep 1
+
+      - name: PHPUnit
+        # Only run if phpunit config file exists
+        if: steps.check_phpunit.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer run test:unit
+
+      - name: Check PHPUnit integration script is defined
+        id: check_integration
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep '^  test:integration ' | wc -l | grep 1
+
+      - name: Run Nextcloud
+        # Only run if phpunit integration config file exists
+        if: steps.check_integration.outcome == 'success'
+        run: php -S localhost:8080 &
+
+      - name: PHPUnit integration
+        # Only run if phpunit integration config file exists
+        if: steps.check_integration.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer run test:integration
+
+      - name: Print logs
+        if: always()
+        run: |
+          cat data/nextcloud.log
+
+      - name: Skipped
+        # Fail the action when neither unit nor integration tests ran
+        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        run: |
+          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          exit 1
+
+  summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest-low
+    needs: [changes, phpunit-sqlite]
+
+    if: always()
+
+    name: phpunit-sqlite-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-sqlite.result != 'success' }}; then exit 1; fi

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
 		"psalm": "psalm --no-cache --threads=$(nproc)",
 		"psalm:update-baseline": "psalm --threads=1 --update-baseline",
 		"rector": "rector --dry-run",
-		"rector:fix": "rector"
+		"rector:fix": "rector",
+		"test:unit": "phpunit --configuration tests/phpunit.xml"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.8"

--- a/lib/BackgroundJob/ExpireUnverifiedAccounts.php
+++ b/lib/BackgroundJob/ExpireUnverifiedAccounts.php
@@ -20,35 +20,17 @@ use Psr\Log\LoggerInterface;
 class ExpireUnverifiedAccounts extends TimedJob {
 	use ExpireUserTrait;
 
-	/** @var string */
-	private $appName;
-
-	/**
-	 * @var IUserManager
-	 */
-	private $userManager;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var ITimeFactory */
-	private $timeFactory;
-
-	/** @var IDBConnection */
-	private $connection;
+	private string $appName = 'preferred_providers';
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		IConfig $config,
+		private IConfig $config,
 		private LoggerInterface $logger,
-		IDBConnection $connection,
+		private IDBConnection $connection,
 		private VerifyMailHelper $mailHelper,
+		private IUserManager $userManager,
 	) {
 		parent::__construct($timeFactory);
-
-		$this->appName = 'preferred_providers';
-		$this->config = $config;
-		$this->connection = $connection;
 
 		// Run once per 15 minutes
 		$this->setInterval(15 * 60);

--- a/tests/Unit/BackgroundJob/ExpireUnverifiedAccountsTest.php
+++ b/tests/Unit/BackgroundJob/ExpireUnverifiedAccountsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\BackgroundJob;
+
+use OCA\Preferred_Providers\BackgroundJob\ExpireUnverifiedAccounts;
+use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\DB\IResult;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class ExpireUnverifiedAccountsTest extends TestCase {
+	private ITimeFactory&MockObject $timeFactory;
+	private IConfig&MockObject $config;
+	private LoggerInterface&MockObject $logger;
+	private IDBConnection&MockObject $connection;
+	private VerifyMailHelper&MockObject $mailHelper;
+	private IUserManager&MockObject $userManager;
+
+	private ExpireUnverifiedAccounts $job;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->connection = $this->createMock(IDBConnection::class);
+		$this->mailHelper = $this->createMock(VerifyMailHelper::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+
+		$this->timeFactory->method('getTime')->willReturn(1000);
+
+		$this->job = new ExpireUnverifiedAccounts(
+			$this->timeFactory,
+			$this->config,
+			$this->logger,
+			$this->connection,
+			$this->mailHelper,
+			$this->userManager,
+		);
+	}
+
+	public function testIsTimedJob(): void {
+		$this->assertInstanceOf(TimedJob::class, $this->job);
+	}
+
+	public function testRunWithNoMatchingUsers(): void {
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturn(false);
+
+		$this->config->method('getSystemValueString')
+			->with('dbtype', 'sqlite')
+			->willReturn('sqlite');
+		$this->connection->expects($this->once())
+			->method('executeQuery')
+			->willReturn($result);
+
+		// Nothing to expire: no user lookups, no mail, no disabling.
+		$this->userManager->expects($this->never())->method('get');
+		$this->mailHelper->expects($this->never())->method('sendMail');
+
+		$this->invokeRun();
+	}
+
+	public function testRunExpiresMatchingUser(): void {
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturnOnConsecutiveCalls(
+			['userid' => 'alice'],
+			false,
+		);
+
+		$this->config->method('getSystemValueString')
+			->with('dbtype', 'sqlite')
+			->willReturn('sqlite');
+		$this->connection->method('executeQuery')->willReturn($result);
+
+		$user = $this->createMock(\OCP\IUser::class);
+		$user->method('isEnabled')->willReturn(true);
+		$user->method('getEMailAddress')->willReturn('alice@example.com');
+		$user->expects($this->once())->method('setEnabled')->with(false);
+
+		$this->userManager->method('get')->with('alice')->willReturn($user);
+
+		$this->config->expects($this->atLeastOnce())
+			->method('deleteUserValue');
+		$this->mailHelper->method('generateTemplate')
+			->with($user, false, true)
+			->willReturn($this->createMock(\OCP\Mail\IEMailTemplate::class));
+		$this->mailHelper->expects($this->once())
+			->method('sendMail')
+			->with($user, $this->anything());
+
+		$this->invokeRun();
+	}
+
+	public function testRunSkipsAlreadyDisabledUser(): void {
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturnOnConsecutiveCalls(
+			['userid' => 'bob'],
+			false,
+		);
+
+		$this->config->method('getSystemValueString')->willReturn('sqlite');
+		$this->connection->method('executeQuery')->willReturn($result);
+
+		$user = $this->createMock(\OCP\IUser::class);
+		$user->method('isEnabled')->willReturn(false);
+		$user->expects($this->never())->method('setEnabled');
+
+		$this->userManager->method('get')->with('bob')->willReturn($user);
+		$this->mailHelper->expects($this->never())->method('sendMail');
+
+		$this->invokeRun();
+	}
+
+	private function invokeRun(): void {
+		$method = new \ReflectionMethod(ExpireUnverifiedAccounts::class, 'run');
+		$method->invoke($this->job, null);
+	}
+}

--- a/tests/Unit/BackgroundJob/NotifyUnsetPasswordTest.php
+++ b/tests/Unit/BackgroundJob/NotifyUnsetPasswordTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\BackgroundJob;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\BackgroundJob\NotifyUnsetPassword;
+use OCA\Preferred_Providers\Mailer\SetPasswordMailHelper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\DB\IResult;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class NotifyUnsetPasswordTest extends TestCase {
+
+	private ITimeFactory&MockObject $timeFactory;
+	private LoggerInterface&MockObject $logger;
+	private IDBConnection&MockObject $connection;
+	private SetPasswordMailHelper&MockObject $mailHelper;
+	private IConfig&MockObject $config;
+
+	private NotifyUnsetPassword $job;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->connection = $this->createMock(IDBConnection::class);
+		$this->mailHelper = $this->createMock(SetPasswordMailHelper::class);
+		$this->config = $this->createMock(IConfig::class);
+
+		$this->timeFactory->method('getTime')->willReturn(1000);
+
+		$this->job = new NotifyUnsetPassword(
+			$this->timeFactory,
+			$this->logger,
+			$this->connection,
+			$this->mailHelper,
+			$this->config,
+		);
+	}
+
+	public function testIsTimedJob(): void {
+		$this->assertInstanceOf(TimedJob::class, $this->job);
+	}
+
+	public function testRunWithNoMatchingUsers(): void {
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturn(false);
+
+		$this->config->method('getSystemValueString')
+			->with('dbtype', 'sqlite')
+			->willReturn('sqlite');
+		$this->connection->expects($this->once())
+			->method('executeQuery')
+			->willReturn($result);
+
+		// No matching users: no mail is generated or sent, no cleanup.
+		$this->mailHelper->expects($this->never())->method('generateTemplate');
+		$this->mailHelper->expects($this->never())->method('sendMail');
+		$this->config->expects($this->never())->method('deleteUserValue');
+
+		$this->invokeRun();
+	}
+
+	public function testRunNotifiesMatchingUser(): void {
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturnOnConsecutiveCalls(
+			['userid' => 'alice'],
+			false,
+		);
+
+		$this->config->method('getSystemValueString')->willReturn('sqlite');
+		$this->connection->method('executeQuery')->willReturn($result);
+
+		$template = $this->createMock(\OCP\Mail\IEMailTemplate::class);
+		$this->mailHelper->expects($this->once())
+			->method('generateTemplate')
+			->with('alice')
+			->willReturn($template);
+		$this->mailHelper->expects($this->once())
+			->method('sendMail')
+			->with('alice', $template);
+
+		// After sending, the reminder flag is deleted so only one mail goes out.
+		$this->config->expects($this->once())
+			->method('deleteUserValue')
+			->with('alice', Application::APP_ID, 'remind_password');
+
+		$this->invokeRun();
+	}
+
+	public function testRunSwallowsSendMailErrors(): void {
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturnOnConsecutiveCalls(
+			['userid' => 'bob'],
+			false,
+		);
+
+		$this->config->method('getSystemValueString')->willReturn('sqlite');
+		$this->connection->method('executeQuery')->willReturn($result);
+
+		$template = $this->createMock(\OCP\Mail\IEMailTemplate::class);
+		$this->mailHelper->method('generateTemplate')->willReturn($template);
+		$this->mailHelper->method('sendMail')
+			->willThrowException(new \Exception('SMTP down'));
+
+		// On failure the reminder flag is not cleared and the error is logged.
+		$this->config->expects($this->never())->method('deleteUserValue');
+		$this->logger->expects($this->atLeastOnce())->method('debug');
+
+		$this->invokeRun();
+	}
+
+	private function invokeRun(): void {
+		$method = new \ReflectionMethod(NotifyUnsetPassword::class, 'run');
+		$method->invoke($this->job, null);
+	}
+}

--- a/tests/Unit/Controller/AccountControllerTest.php
+++ b/tests/Unit/Controller/AccountControllerTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Controller;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Controller\AccountController;
+use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Mail\IMailer;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class AccountControllerTest extends TestCase {
+
+	private IConfig&MockObject $config;
+	private IAppConfig&MockObject $appConfig;
+	private IUserManager&MockObject $userManager;
+	private IGroupManager&MockObject $groupManager;
+	private IMailer&MockObject $mailer;
+	private VerifyMailHelper&MockObject $verifyMailHelper;
+	private LoggerInterface&MockObject $logger;
+	private IURLGenerator&MockObject $urlGenerator;
+	private ITimeFactory&MockObject $timeFactory;
+	private ICrypto&MockObject $crypto;
+	private ISecureRandom&MockObject $secureRandom;
+	private IManager&MockObject $notificationsManager;
+
+	private AccountController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->verifyMailHelper = $this->createMock(VerifyMailHelper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->notificationsManager = $this->createMock(IManager::class);
+
+		$this->controller = new AccountController(
+			Application::APP_ID,
+			$this->createMock(IRequest::class),
+			$this->config,
+			$this->userManager,
+			$this->groupManager,
+			$this->mailer,
+			$this->verifyMailHelper,
+			$this->logger,
+			$this->urlGenerator,
+			$this->timeFactory,
+			$this->crypto,
+			$this->secureRandom,
+			$this->notificationsManager,
+			$this->appConfig,
+		);
+	}
+
+	public function testRequestAccountInvalidToken(): void {
+		$this->appConfig->method('getValueString')
+			->with(Application::APP_ID, 'provider_token')
+			->willReturn('the-real-token');
+
+		$response = $this->controller->requestAccount('wrong-token', 'user@example.com');
+
+		$this->assertInstanceOf(DataResponse::class, $response);
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}
+
+	public function testRequestAccountEmptyServerTokenIsRejected(): void {
+		$this->appConfig->method('getValueString')
+			->with(Application::APP_ID, 'provider_token')
+			->willReturn('');
+
+		$response = $this->controller->requestAccount('', 'user@example.com');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}
+
+	public function testRequestAccountInvalidMail(): void {
+		$this->appConfig->method('getValueString')
+			->with(Application::APP_ID, 'provider_token')
+			->willReturn('token');
+		$this->mailer->method('validateMailAddress')->with('not-a-mail')->willReturn(false);
+
+		$response = $this->controller->requestAccount('token', 'not-a-mail');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testRequestAccountUserAlreadyExists(): void {
+		$this->appConfig->method('getValueString')
+			->with(Application::APP_ID, 'provider_token')
+			->willReturn('token');
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->userManager->method('userExists')->with('user@example.com')->willReturn(true);
+
+		$response = $this->controller->requestAccount('token', 'user@example.com');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testRequestAccountHappyPath(): void {
+		$email = 'user@example.com';
+
+		$this->appConfig->method('getValueString')
+			->willReturnCallback(static fn (string $app, string $key, string $default = ''): string => match ($key) {
+				'provider_token' => 'token',
+				'provider_groups' => 'partners',
+				default => '',
+			});
+		$this->mailer->method('validateMailAddress')->willReturn(true);
+		$this->userManager->method('userExists')->willReturn(false);
+
+		$newUser = $this->createMock(IUser::class);
+		$this->userManager->method('createUser')->with($email, $this->isType('string'))->willReturn($newUser);
+		$newUser->expects($this->once())->method('setSystemEMailAddress')->with($email);
+
+		// The controller merges provider_groups with the (empty) unconfirmed
+		// groups, so it also probes an empty group id: keep the stub lenient.
+		$group = $this->createMock(IGroup::class);
+		$this->groupManager->method('groupExists')->willReturnCallback(static fn (string $gid): bool => $gid === 'partners');
+		$this->groupManager->method('get')->willReturn($group);
+		$group->expects($this->once())->method('addUser')->with($newUser);
+
+		$this->timeFactory->method('getTime')->willReturn(1000);
+		$this->secureRandom->method('generate')->willReturn('random-value');
+		$this->crypto->method('encrypt')->willReturn('encrypted');
+
+		$notification = $this->createMock(INotification::class);
+		$notification->method($this->anything())->willReturnSelf();
+		$this->notificationsManager->method('createNotification')->willReturn($notification);
+		$this->notificationsManager->expects($this->once())->method('notify')->with($notification);
+
+		$this->verifyMailHelper->expects($this->once())->method('sendMail');
+		$this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud/set-password');
+
+		$response = $this->controller->requestAccount('token', $email);
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame('https://cloud/set-password', $data['data']['setPassword']);
+	}
+}

--- a/tests/Unit/Controller/MailControllerTest.php
+++ b/tests/Unit/Controller/MailControllerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Controller;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Controller\AccountController;
+use OCA\Preferred_Providers\Controller\MailController;
+use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Security\ICrypto;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class MailControllerTest extends TestCase {
+
+	private IConfig&MockObject $config;
+	private IL10N&MockObject $l10n;
+	private LoggerInterface&MockObject $logger;
+	private IUserManager&MockObject $userManager;
+	private ICrypto&MockObject $crypto;
+	private ITimeFactory&MockObject $timeFactory;
+	private IURLGenerator&MockObject $urlGenerator;
+	private VerifyMailHelper&MockObject $verifyMailHelper;
+	private IGroupManager&MockObject $groupManager;
+	private IAppConfig&MockObject $appConfig;
+
+	private MailController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->verifyMailHelper = $this->createMock(VerifyMailHelper::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+
+		$this->l10n->method('t')->willReturnArgument(0);
+
+		$this->controller = new MailController(
+			Application::APP_ID,
+			$this->createMock(IRequest::class),
+			$this->config,
+			$this->l10n,
+			$this->logger,
+			$this->userManager,
+			$this->crypto,
+			$this->timeFactory,
+			$this->urlGenerator,
+			$this->verifyMailHelper,
+			$this->groupManager,
+			$this->appConfig,
+		);
+	}
+
+	public function testConfirmMailAddressInvalidToken(): void {
+		$email = 'user@example.com';
+
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(true);
+		$user->method('getEMailAddress')->willReturn($email);
+		$this->userManager->method('get')->with($email)->willReturn($user);
+
+		$this->config->method('getUserValue')->willReturn('encrypted');
+		$this->config->method('getSystemValue')->willReturn('secret');
+		$this->crypto->method('decrypt')->willReturn('9999999999:wrongtoken');
+		$this->timeFactory->method('getTime')->willReturn(2000000000);
+
+		$response = $this->controller->confirmMailAddress($email, 'validtoken');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+	}
+
+	public function testConfirmMailAddressUserNull(): void {
+		$email = 'user@example.com';
+
+		$this->userManager->method('get')->with($email)->willReturn(null);
+
+		$response = $this->controller->confirmMailAddress($email, 'validtoken');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+	}
+
+	public function testConfirmMailAddressHappyPath(): void {
+		$email = 'user@example.com';
+		$token = 'validtoken';
+
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(true);
+		$user->method('getEMailAddress')->willReturn($email);
+		$this->userManager->method('get')->with($email)->willReturn($user);
+
+		$this->config->method('getUserValue')->willReturn('encrypted');
+		$this->config->method('getSystemValue')->willReturn('secret');
+
+		$this->timeFactory->method('getTime')->willReturn(2000000000);
+		// recent enough: time - 100 is well within the validateEmailDelay window
+		$decrypted = (2000000000 - 100) . ':' . $token;
+		$this->crypto->method('decrypt')->willReturn($decrypted);
+
+		// remove user deadline & token
+		$this->config->expects($this->exactly(2))
+			->method('deleteUserValue')
+			->willReturnCallback(function (string $userId, string $appName, string $key): void {
+				$this->assertSame('user@example.com', $userId);
+				$this->assertSame(Application::APP_ID, $appName);
+				$this->assertContains($key, ['disable_user_after', 'verify_token']);
+			});
+
+		// welcome mail
+		$this->verifyMailHelper->expects($this->once())
+			->method('generateTemplate')
+			->with($user, true)
+			->willReturn($this->createMock(\OCP\Mail\IEMailTemplate::class));
+		$this->verifyMailHelper->expects($this->once())->method('sendMail');
+
+		// keep group loops empty
+		$this->appConfig->method('getValueString')->willReturn('');
+		$this->groupManager->method('groupExists')->willReturn(false);
+
+		$this->urlGenerator->method('getAbsoluteURL')->with('/')->willReturn('https://cloud/');
+
+		$response = $this->controller->confirmMailAddress($email, $token);
+
+		$this->assertInstanceOf(RedirectResponse::class, $response);
+
+		// sanity check the constant referenced by the controller
+		$this->assertSame(21600, AccountController::validateEmailDelay);
+	}
+}

--- a/tests/Unit/Controller/PasswordControllerTest.php
+++ b/tests/Unit/Controller/PasswordControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Controller;
+
+use OC\Authentication\Token\IProvider;
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Controller\PasswordController;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class PasswordControllerTest extends TestCase {
+
+	private IConfig&MockObject $config;
+	private IL10N&MockObject $l10n;
+	private IUserManager&MockObject $userManager;
+	private ICrypto&MockObject $crypto;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IUserSession&MockObject $userSession;
+	private LoggerInterface&MockObject $logger;
+	private IProvider&MockObject $tokenProvider;
+	private ISecureRandom&MockObject $secureRandom;
+
+	private PasswordController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->tokenProvider = $this->createMock(IProvider::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+
+		$this->l10n->method('t')->willReturnArgument(0);
+
+		$this->controller = new PasswordController(
+			Application::APP_ID,
+			$this->createMock(IRequest::class),
+			$this->config,
+			$this->l10n,
+			$this->userManager,
+			$this->crypto,
+			$this->urlGenerator,
+			$this->userSession,
+			$this->logger,
+			$this->tokenProvider,
+			$this->secureRandom,
+		);
+	}
+
+	public function testSetPasswordInvalidToken(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(true);
+		$this->userManager->method('get')->with('user@example.com')->willReturn($user);
+
+		$this->config->method('getUserValue')
+			->with('user@example.com', Application::APP_ID, 'set_password')
+			->willReturn('encrypted');
+		$this->config->method('getSystemValue')->willReturn('secret');
+		// Decrypted token does not match the passed one -> hash_equals fails
+		$this->crypto->method('decrypt')->willReturn('the-real-token');
+
+		$response = $this->controller->setPassword('wrong-token', 'user@example.com');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+	}
+
+	public function testSetPasswordUnknownUser(): void {
+		$this->userManager->method('get')->with('user@example.com')->willReturn(null);
+
+		$response = $this->controller->setPassword('any-token', 'user@example.com');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+	}
+
+	public function testSubmitPasswordTooLong(): void {
+		$token = 'valid-token';
+
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(true);
+		$this->userManager->method('get')->with('user@example.com')->willReturn($user);
+
+		$this->config->method('getUserValue')
+			->with('user@example.com', Application::APP_ID, 'set_password')
+			->willReturn('encrypted');
+		$this->config->method('getSystemValue')->willReturn('secret');
+		// Token check passes: decrypted token equals passed token
+		$this->crypto->method('decrypt')->willReturn($token);
+
+		$password = str_repeat('a', 101);
+
+		$response = $this->controller->submitPassword($token, 'user@example.com', $password);
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+	}
+
+	public function testSubmitPasswordInvalidToken(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(true);
+		$this->userManager->method('get')->with('user@example.com')->willReturn($user);
+
+		$this->config->method('getUserValue')
+			->with('user@example.com', Application::APP_ID, 'set_password')
+			->willReturn('encrypted');
+		$this->config->method('getSystemValue')->willReturn('secret');
+		// Token check fails before the length check
+		$this->crypto->method('decrypt')->willReturn('the-real-token');
+
+		$response = $this->controller->submitPassword('wrong-token', 'user@example.com', 'short');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+	}
+}

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Controller;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Controller\SettingsController;
+use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Mail\IEMailTemplate;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class SettingsControllerTest extends TestCase {
+
+	private IConfig&MockObject $config;
+	private IUserManager&MockObject $userManager;
+	private IGroupManager&MockObject $groupManager;
+	private LoggerInterface&MockObject $logger;
+	private ITimeFactory&MockObject $timeFactory;
+	private IAppManager&MockObject $appManager;
+	private ISecureRandom&MockObject $secureRandom;
+	private IManager&MockObject $notificationsManager;
+	private VerifyMailHelper&MockObject $verifyMailHelper;
+	private IAppConfig&MockObject $appConfig;
+
+	private SettingsController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->notificationsManager = $this->createMock(IManager::class);
+		$this->verifyMailHelper = $this->createMock(VerifyMailHelper::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+
+		// The constructor computes $this->appRoot = $this->appManager->getAppPath($appName)
+		// so this must be stubbed before instantiating the controller.
+		$this->appManager->method('getAppPath')->willReturn('/tmp/app');
+
+		$this->controller = new SettingsController(
+			Application::APP_ID,
+			$this->createMock(IRequest::class),
+			$this->config,
+			$this->userManager,
+			$this->groupManager,
+			$this->logger,
+			$this->timeFactory,
+			$this->appManager,
+			$this->secureRandom,
+			$this->notificationsManager,
+			$this->verifyMailHelper,
+			$this->appConfig,
+		);
+	}
+
+	public function testResetToken(): void {
+		$this->secureRandom->method('generate')->with(10)->willReturn('random-string');
+
+		$this->appConfig->expects($this->once())
+			->method('setValueString')
+			->with('preferred_providers', 'provider_token', $this->isType('string'));
+
+		$response = $this->controller->resetToken();
+
+		$this->assertInstanceOf(DataResponse::class, $response);
+		$data = $response->getData();
+		$this->assertArrayHasKey('token', $data);
+		$this->assertSame(md5('random-string'), $data['token']);
+	}
+
+	public function testSetGroupsForAll(): void {
+		$this->groupManager->method('groupExists')->with('g1')->willReturn(true);
+
+		$this->appConfig->expects($this->once())
+			->method('setValueString')
+			->with('preferred_providers', 'provider_groups', 'g1');
+
+		$response = $this->controller->setGroups(['g1'], 'all');
+
+		$this->assertInstanceOf(DataResponse::class, $response);
+		$this->assertSame(['g1'], $response->getData()['groups']);
+	}
+
+	public function testSetGroupsForConfirmed(): void {
+		$this->groupManager->method('groupExists')->with('g1')->willReturn(true);
+
+		$this->appConfig->expects($this->once())
+			->method('setValueString')
+			->with('preferred_providers', 'provider_groups_confirmed', 'g1');
+
+		$response = $this->controller->setGroups(['g1'], 'confirmed');
+
+		$this->assertInstanceOf(DataResponse::class, $response);
+		$this->assertSame(['g1'], $response->getData()['groups']);
+	}
+
+	public function testSetGroupsMissingGroupThrows(): void {
+		$this->groupManager->method('groupExists')->with('missing')->willReturn(false);
+
+		$this->expectException(OCSNotFoundException::class);
+
+		$this->controller->setGroups(['missing']);
+	}
+
+	public function testSetGroupsBogusTargetThrows(): void {
+		$this->groupManager->method('groupExists')->with('g1')->willReturn(true);
+
+		$this->expectException(OCSBadRequestException::class);
+
+		$this->controller->setGroups(['g1'], 'bogus');
+	}
+
+	public function testReactivateUnknownUserThrows(): void {
+		$this->userManager->method('get')->with('nouser')->willReturn(null);
+
+		$this->expectException(OCSNotFoundException::class);
+
+		$this->controller->reactivate('nouser');
+	}
+
+	public function testReactivateUserWithoutEmailThrows(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn(null);
+		$this->userManager->method('get')->with('user')->willReturn($user);
+
+		$this->expectException(OCSBadRequestException::class);
+
+		$this->controller->reactivate('user');
+	}
+
+	public function testReactivateHappyPath(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('user@example.com');
+		$user->method('isEnabled')->willReturn(true);
+		$user->expects($this->never())->method('setEnabled');
+		$this->userManager->method('get')->with('user')->willReturn($user);
+
+		$emailTemplate = $this->createMock(IEMailTemplate::class);
+		$this->verifyMailHelper->expects($this->once())
+			->method('generateTemplate')
+			->with($user)
+			->willReturn($emailTemplate);
+		$this->verifyMailHelper->expects($this->once())
+			->method('sendMail')
+			->with($user, $emailTemplate);
+
+		$notification = $this->createMock(INotification::class);
+		$notification->method($this->anything())->willReturnSelf();
+		$this->notificationsManager->method('createNotification')->willReturn($notification);
+		$this->notificationsManager->expects($this->once())->method('notify')->with($notification);
+
+		$response = $this->controller->reactivate('user');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(['status' => 'success'], $response->getData());
+	}
+}

--- a/tests/Unit/Mailer/SetPasswordMailHelperTest.php
+++ b/tests/Unit/Mailer/SetPasswordMailHelperTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Mailer;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Mailer\SetPasswordMailHelper;
+use OCA\Theming\ThemingDefaults;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Mail\IEMailTemplate;
+use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
+use OCP\Security\ICrypto;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class SetPasswordMailHelperTest extends TestCase {
+
+	private ThemingDefaults&MockObject $themingDefaults;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IL10N&MockObject $l10n;
+	private IMailer&MockObject $mailer;
+	private IConfig&MockObject $config;
+	private ICrypto&MockObject $crypto;
+
+	private SetPasswordMailHelper $helper;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+
+		$this->l10n->method('t')->willReturnArgument(0);
+		$this->themingDefaults->method('getName')->willReturn('TestCloud');
+		$this->mailer->method('createEMailTemplate')
+			->willReturn($this->createMock(IEMailTemplate::class));
+
+		$this->helper = new SetPasswordMailHelper(
+			Application::APP_ID,
+			$this->themingDefaults,
+			$this->urlGenerator,
+			$this->l10n,
+			$this->mailer,
+			$this->config,
+			$this->crypto,
+		);
+	}
+
+	public function testGenerateTemplate(): void {
+		$this->config->method('getUserValue')
+			->with('u@e.com', Application::APP_ID, 'set_password')
+			->willReturn('encrypted-token');
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->willReturn('the-token');
+
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->willReturn('https://cloud/set-password');
+
+		$template = $this->helper->generateTemplate('u@e.com', false);
+
+		$this->assertInstanceOf(IEMailTemplate::class, $template);
+	}
+
+	public function testSendMail(): void {
+		$template = $this->createMock(IEMailTemplate::class);
+
+		$message = $this->createMock(IMessage::class);
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+		$message->expects($this->once())
+			->method('setTo')
+			->with(['u@e.com']);
+		$message->expects($this->once())
+			->method('useTemplate')
+			->with($template);
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$this->helper->sendMail('u@e.com', $template);
+	}
+
+	public function testSetL10N(): void {
+		$newL10n = $this->createMock(IL10N::class);
+
+		$this->helper->setL10N($newL10n);
+
+		$this->addToAssertionCount(1);
+	}
+}

--- a/tests/Unit/Mailer/VerifyMailHelperTest.php
+++ b/tests/Unit/Mailer/VerifyMailHelperTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Mailer;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
+use OCA\Theming\ThemingDefaults;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Mail\IEMailTemplate;
+use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class VerifyMailHelperTest extends TestCase {
+
+	private ThemingDefaults&MockObject $themingDefaults;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IL10N&MockObject $l10n;
+	private IMailer&MockObject $mailer;
+	private ISecureRandom&MockObject $secureRandom;
+	private ITimeFactory&MockObject $timeFactory;
+	private IConfig&MockObject $config;
+	private ICrypto&MockObject $crypto;
+
+	private VerifyMailHelper $helper;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+
+		$this->l10n->method('t')->willReturnArgument(0);
+		$this->themingDefaults->method('getName')->willReturn('TestCloud');
+		$this->mailer->method('createEMailTemplate')
+			->willReturn($this->createMock(IEMailTemplate::class));
+
+		$this->helper = new VerifyMailHelper(
+			Application::APP_ID,
+			$this->themingDefaults,
+			$this->urlGenerator,
+			$this->l10n,
+			$this->mailer,
+			$this->secureRandom,
+			$this->timeFactory,
+			$this->config,
+			$this->crypto,
+		);
+	}
+
+	public function testGenerateTemplateNotVerified(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user1');
+		$user->method('getEMailAddress')->willReturn('u@e.com');
+
+		$this->secureRandom->method('generate')->willReturn('the-token');
+		$this->timeFactory->method('getTime')->willReturn(1000);
+		$this->crypto->method('encrypt')->willReturn('enc');
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('user1', Application::APP_ID, 'verify_token', 'enc');
+
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->willReturn('https://cloud/confirm');
+		$this->urlGenerator->expects($this->never())->method('getAbsoluteURL');
+
+		$template = $this->helper->generateTemplate($user, false);
+
+		$this->assertInstanceOf(IEMailTemplate::class, $template);
+	}
+
+	public function testGenerateTemplateVerified(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user1');
+		$user->method('getEMailAddress')->willReturn('u@e.com');
+
+		$this->secureRandom->method('generate')->willReturn('the-token');
+		$this->timeFactory->method('getTime')->willReturn(1000);
+		$this->crypto->method('encrypt')->willReturn('enc');
+
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('/')
+			->willReturn('https://cloud/');
+		$this->urlGenerator->expects($this->never())->method('linkToRouteAbsolute');
+
+		$template = $this->helper->generateTemplate($user, true);
+
+		$this->assertInstanceOf(IEMailTemplate::class, $template);
+	}
+
+	public function testSendMail(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('u@e.com');
+		$user->method('getDisplayName')->willReturn('U');
+
+		$template = $this->createMock(IEMailTemplate::class);
+
+		$message = $this->createMock(IMessage::class);
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+		$message->expects($this->once())
+			->method('setTo')
+			->with(['u@e.com' => 'U']);
+		$message->expects($this->once())
+			->method('useTemplate')
+			->with($template);
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$this->helper->sendMail($user, $template);
+	}
+}

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preferred_Providers\Tests\Unit\Notification;
+
+use OCA\Preferred_Providers\AppInfo\Application;
+use OCA\Preferred_Providers\Notification\Notifier;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class NotifierTest extends TestCase {
+
+	private IFactory&MockObject $l10nFactory;
+	private IUserManager&MockObject $userManager;
+	private IURLGenerator&MockObject $urlGenerator;
+
+	private Notifier $notifier;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10nFactory = $this->createMock(IFactory::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+
+		$this->notifier = new Notifier(
+			Application::APP_ID,
+			$this->l10nFactory,
+			$this->userManager,
+			$this->urlGenerator,
+		);
+	}
+
+	public function testGetID(): void {
+		$this->assertSame(Application::APP_ID, $this->notifier->getID());
+	}
+
+	public function testGetName(): void {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+		$this->l10nFactory->method('get')
+			->with(Application::APP_ID)
+			->willReturn($l10n);
+
+		$this->assertSame('Simple signup', $this->notifier->getName());
+	}
+
+	public function testPrepareWrongApp(): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('other_app');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Incorrect app');
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testPrepareUnknownSubject(): void {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+		$this->l10nFactory->method('get')->willReturn($l10n);
+
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn(Application::APP_ID);
+		$notification->method('getSubject')->willReturn('some_unknown_subject');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Unknown subject');
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testPrepareVerifyEmail(): void {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+		$this->l10nFactory->method('get')
+			->with(Application::APP_ID, 'en')
+			->willReturn($l10n);
+
+		$this->urlGenerator->method('imagePath')
+			->with(Application::APP_ID, 'app-dark.svg')
+			->willReturn('/img/app-dark.svg');
+		$this->urlGenerator->method('getAbsoluteURL')
+			->with('/img/app-dark.svg')
+			->willReturn('https://cloud/img/app-dark.svg');
+
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn(Application::APP_ID);
+		$notification->method('getSubject')->willReturn('verify_email');
+		$notification->method('getUser')->willReturn('user@example.com');
+
+		$notification->expects($this->once())
+			->method('setIcon')
+			->with('https://cloud/img/app-dark.svg')
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setParsedSubject')
+			->with('Please verify your email address')
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setParsedMessage')
+			->with('A confirmation mail was sent to user@example.com. Make sure to confirm the account within 6 hours.')
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setRichMessage')
+			->willReturnSelf();
+
+		$result = $this->notifier->prepare($notification, 'en');
+
+		$this->assertSame($notification, $result);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+use PHPUnit\Framework\TestCase;
+
+if (!defined('PHPUNIT_RUN')) {
+	define('PHPUNIT_RUN', 1);
+}
+
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/autoload.php';
+
+Server::get(IAppManager::class)->loadApp('preferred_providers');
+
+if (!class_exists(TestCase::class)) {
+	require_once('PHPUnit/Autoload.php');
+}
+
+\OC_Hook::clear();

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<phpunit bootstrap="bootstrap.php"
+	colors="true"
+	convertDeprecationsToExceptions="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	forceCoversAnnotation="false"
+>
+	<testsuites>
+		<testsuite name="unit">
+			<directory>./Unit</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
+			<directory suffix=".php">../lib</directory>
+		</include>
+	</coverage>
+</phpunit>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -8,7 +8,6 @@
   <file src="lib/BackgroundJob/ExpireUnverifiedAccounts.php">
     <MissingDependency>
       <code><![CDATA[ITimeFactory]]></code>
-      <code><![CDATA[ITimeFactory]]></code>
     </MissingDependency>
   </file>
   <file src="lib/BackgroundJob/NotifyUnsetPassword.php">

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -1,0 +1,11 @@
+{
+	"config": {
+		"platform": {
+			"php": "8.1"
+		},
+		"sort-packages": true
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9.6"
+	}
+}


### PR DESCRIPTION
> **Stacked on #158** — base branch is `feature/modernize-php-tooling`. Review/merge #158 first; this targets it so the diff stays scoped to the tests. Will retarget to `main` once #158 lands.


The app had **zero tests**. This adds a server-based PHPUnit suite (the current Nextcloud standard) covering the high-risk logic, plus the CI to run it.


---
### AI assistance disclosure
Per the [Nextcloud AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md), this PR was developed with AI assistance (Claude Code, `claude-opus-4-8`); each commit carries an `Assisted-by: ClaudeCode:claude-opus-4-8` trailer. I have reviewed and tested every change, take authorship of it, and can explain and defend it.
