### PR TITLE
fix: constructor property promotion follow-up

### DIFF
--- a/lib/BackgroundJob/ExpireUnverifiedAccounts.php
+++ b/lib/BackgroundJob/ExpireUnverifiedAccounts.php
@@ -24,11 +24,11 @@ class ExpireUnverifiedAccounts extends TimedJob {
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		private IConfig $config,
-		private LoggerInterface $logger,
-		private IDBConnection $connection,
-		private VerifyMailHelper $mailHelper,
-		private IUserManager $userManager,
+		private readonly IConfig $config,
+		private readonly LoggerInterface $logger,
+		private readonly IDBConnection $connection,
+		private readonly VerifyMailHelper $mailHelper,
+		private readonly IUserManager $userManager,
 	) {
 		parent::__construct($timeFactory);
 

--- a/lib/BackgroundJob/ExpireUnverifiedAccounts.php
+++ b/lib/BackgroundJob/ExpireUnverifiedAccounts.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Preferred_Providers\BackgroundJob;
 
+use OCA\Preferred_Providers\AppInfo\Application;
 use OCA\Preferred_Providers\Helper\ExpireUserTrait;
 use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -19,8 +20,6 @@ use Psr\Log\LoggerInterface;
 
 class ExpireUnverifiedAccounts extends TimedJob {
 	use ExpireUserTrait;
-
-	private string $appName = 'preferred_providers';
 
 	public function __construct(
 		ITimeFactory $timeFactory,
@@ -42,7 +41,7 @@ class ExpireUnverifiedAccounts extends TimedJob {
 	#[\Override]
 	public function run($argument) {
 		// process if token is 5min old
-		$users = $this->getUsersForUserLowerThanValue($this->appName, 'disable_user_after', strval(time()));
+		$users = $this->getUsersForUserLowerThanValue(Application::APP_ID, 'disable_user_after', strval(time()));
 		foreach ($users as $userId) {
 			$this->expireUser($userId);
 		}

--- a/lib/BackgroundJob/NotifyUnsetPassword.php
+++ b/lib/BackgroundJob/NotifyUnsetPassword.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Preferred_Providers\BackgroundJob;
 
 use Exception;
+use OCA\Preferred_Providers\AppInfo\Application;
 use OCA\Preferred_Providers\Mailer\SetPasswordMailHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
@@ -17,8 +18,6 @@ use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 
 class NotifyUnsetPassword extends TimedJob {
-
-	private string $appName = 'preferred_providers';
 
 	public function __construct(
 		ITimeFactory $timeFactory,
@@ -39,13 +38,13 @@ class NotifyUnsetPassword extends TimedJob {
 	#[\Override]
 	public function run($argument) {
 		// process if token is 5min old
-		$users = $this->getUsersForUserLowerThanValue($this->appName, 'remind_password', strval(time() - 5 * 60));
+		$users = $this->getUsersForUserLowerThanValue(Application::APP_ID, 'remind_password', strval(time() - 5 * 60));
 		foreach ($users as $userId) {
 			$emailTemplate = $this->mailHelper->generateTemplate($userId);
 			try {
 				$this->mailHelper->sendMail($userId, $emailTemplate);
 				// only send one mail
-				$this->config->deleteUserValue($userId, $this->appName, 'remind_password');
+				$this->config->deleteUserValue($userId, Application::APP_ID, 'remind_password');
 				$this->logger->debug('Password definition mail sent to ' . $userId);
 			} catch (Exception) {
 				$this->logger->debug('Error while sending the password definition mail to  ' . $userId);

--- a/lib/BackgroundJob/NotifyUnsetPassword.php
+++ b/lib/BackgroundJob/NotifyUnsetPassword.php
@@ -18,26 +18,16 @@ use Psr\Log\LoggerInterface;
 
 class NotifyUnsetPassword extends TimedJob {
 
-	/** @var string */
-	private $appName;
-
-	/** @var IDBConnection */
-	private $connection;
-
-	/** @var IConfig */
-	private $config;
+	private string $appName = 'preferred_providers';
 
 	public function __construct(
 		ITimeFactory $timeFactory,
 		private readonly LoggerInterface $logger,
-		IDBConnection $connection,
+		private readonly IDBConnection $connection,
 		private readonly SetPasswordMailHelper $mailHelper,
-		IConfig $config,
+		private readonly IConfig $config,
 	) {
 		parent::__construct($timeFactory);
-		$this->appName = 'preferred_providers';
-		$this->connection = $connection;
-		$this->config = $config;
 
 		// Run once per 5 minutes
 		$this->setInterval(5 * 60);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Preferred_Providers\Controller;
 
+use OCA\Preferred_Providers\AppInfo\Application;
 use OCA\Preferred_Providers\Mailer\VerifyMailHelper;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
@@ -60,7 +61,7 @@ class SettingsController extends OCSController {
 	#[ApiRoute(verb: 'GET', url: '/api/v1/token/new')]
 	public function resetToken(): DataResponse {
 		$provider_token = md5($this->secureRandom->generate(10));
-		$this->appConfig->setValueString('preferred_providers', 'provider_token', $provider_token);
+		$this->appConfig->setValueString(Application::APP_ID, 'provider_token', $provider_token);
 
 		return new DataResponse(['token' => $provider_token]);
 	}
@@ -81,9 +82,9 @@ class SettingsController extends OCSController {
 		}
 
 		if ($for === 'all') {
-			$this->appConfig->setValueString('preferred_providers', 'provider_groups', implode(',', $groups));
+			$this->appConfig->setValueString(Application::APP_ID, 'provider_groups', implode(',', $groups));
 		} elseif ($for === 'confirmed' || $for === 'unconfirmed') {
-			$this->appConfig->setValueString('preferred_providers', 'provider_groups_' . $for, implode(',', $groups));
+			$this->appConfig->setValueString(Application::APP_ID, 'provider_groups_' . $for, implode(',', $groups));
 		} else {
 			throw new OCSBadRequestException();
 		}

--- a/lib/Helper/ExpireUserTrait.php
+++ b/lib/Helper/ExpireUserTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Preferred_Providers\Helper;
 
 use Exception;
+use OCA\Preferred_Providers\AppInfo\Application;
 
 trait ExpireUserTrait {
 
@@ -29,7 +30,7 @@ trait ExpireUserTrait {
 		$user->setEnabled(false);
 
 		// removing token to avoid conflict with further manual manipulation of the user
-		$this->config->deleteUserValue($userId, $this->appName, 'disable_user_after');
+		$this->config->deleteUserValue($userId, Application::APP_ID, 'disable_user_after');
 		$this->logger->info('User ' . $userId . ' failed to verify email in time and has been disabled');
 
 		// send email
@@ -38,7 +39,7 @@ trait ExpireUserTrait {
 			try {
 				$this->mailHelper->sendMail($user, $emailTemplate);
 				// only send one mail
-				$this->config->deleteUserValue($userId, $this->appName, 'remind_password');
+				$this->config->deleteUserValue($userId, Application::APP_ID, 'remind_password');
 				$this->logger->debug('Unverified warning mail sent to ' . $userId);
 			} catch (Exception) {
 				$this->logger->error('Error while sending the failed to verify warning mail to  ' . $userId);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Preferred_Providers\Settings;
 
+use OCA\Preferred_Providers\AppInfo\Application;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -76,7 +77,7 @@ class Admin implements ISettings {
 	 */
 	#[\Override]
 	public function getSection() {
-		return 'preferred_providers';
+		return Application::APP_ID;
 	}
 
 	/**

--- a/lib/Settings/Section.php
+++ b/lib/Settings/Section.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\Preferred_Providers\Settings;
 
+use OCA\Preferred_Providers\AppInfo\Application;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
@@ -35,7 +36,7 @@ class Section implements IIconSection {
 	 */
 	#[\Override]
 	public function getID() {
-		return 'preferred_providers';
+		return Application::APP_ID;
 	}
 
 	/**
@@ -66,6 +67,6 @@ class Section implements IIconSection {
 	 */
 	#[\Override]
 	public function getIcon() {
-		return $this->url->imagePath('preferred_providers', 'app-dark.svg');
+		return $this->url->imagePath(Application::APP_ID, 'app-dark.svg');
 	}
 }

--- a/templates/flow-login.php
+++ b/templates/flow-login.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-\OCP\Util::addScript('preferred_providers', 'flow-login');
-\OCP\Util::addStyle('preferred_providers', 'password-public');
+\OCP\Util::addScript(\OCA\Preferred_Providers\AppInfo\Application::APP_ID, 'flow-login');
+\OCP\Util::addStyle(\OCA\Preferred_Providers\AppInfo\Application::APP_ID, 'password-public');
 
 ?>
 <div class="guest-box login-box" id="flow-login"

--- a/templates/password-public.php
+++ b/templates/password-public.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-\OCP\Util::addScript('preferred_providers', 'password-public');
-\OCP\Util::addStyle('preferred_providers', 'password-public');
+\OCP\Util::addScript(\OCA\Preferred_Providers\AppInfo\Application::APP_ID, 'password-public');
+\OCP\Util::addStyle(\OCA\Preferred_Providers\AppInfo\Application::APP_ID, 'password-public');
 
 ?>
 <div class="guest-box login-box">

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-\OCP\Util::addScript('preferred_providers', 'admin-settings');
-\OCP\Util::addStyle('preferred_providers', 'admin-settings');
+\OCP\Util::addScript(\OCA\Preferred_Providers\AppInfo\Application::APP_ID, 'admin-settings');
+\OCP\Util::addStyle(\OCA\Preferred_Providers\AppInfo\Application::APP_ID, 'admin-settings');
 ?>
 
 <div id="token-section" class="section">


### PR DESCRIPTION
Follow-up to #158, addresses Carl's review comment: the constructor property promotion was only half done in the two background job classes.
Also fixed the multiple app id consts :shrug: 

---
Developed with AI assistance (Claude Code, `claude-opus-4-8`), disclosed per the [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md). Reviewed and tested; I take authorship.