### PR TITLE
test(e2e): Playwright suite for the full account lifecycle

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+name: Playwright
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+      - stable*
+
+concurrency:
+  group: playwright-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  APP_NAME: preferred_providers
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest-low
+    outputs:
+      # full supported server range derived from info.xml (min → max, incl. master)
+      branches: ${{ steps.versions.outputs.branches }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
+
+  playwright:
+    runs-on: ubuntu-latest
+    needs: matrix
+
+    strategy:
+      fail-fast: false
+      matrix:
+        server-versions: ${{ fromJson(needs.matrix.outputs.branches) }}
+
+    name: Playwright (${{ matrix.server-versions }})
+
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          cache: 'npm'
+          node-version-file: 'package.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          CI: true
+          SERVER_BRANCH: ${{ matrix.server-versions }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: playwright-results-${{ matrix.server-versions }}
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 5
+
+  summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest-low
+    needs: playwright
+
+    if: always()
+
+    name: playwright-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.playwright.result != 'success' && needs.playwright.result != 'skipped' }}; then exit 1; fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,14 @@ css/vendor
 css/style.css
 coverage
 npm-debug.log
-package-lock.json
 vendor
 vendor-bin/*/vendor
 vendor-bin/*/composer.lock
 .php-cs-fixer.cache
 .php_cs.cache
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -24,6 +24,8 @@ path = [
 	"composer.lock",
 	"vendor-bin/**/composer.json",
 	"tests/psalm-baseline.xml",
+	"package.json",
+	"package-lock.json",
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2018 Nextcloud GmbH and Nextcloud contributors"

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -1,34 +1,93 @@
-$('#token-reset:not(:disabled)').click(_.debounce(function() {
-	$('#token-reset').attr('disabled', true);
-	$('#token').addClass('icon-loading');
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
-	$.get(OC.linkToOCS('apps/preferred_providers/api/v1/token', 2)+ 'new', function(response) {
-		$('#token').val(response.ocs.data.token);
-		$('#token-reset').attr('disabled', false);
-		$('#token').removeClass('icon-loading');
-	}, 'json');
-}, 250));
+// Dependency-free: jQuery, underscore and OC.linkToOCS are no longer part of the
+// default server bundle on modern Nextcloud, so this uses vanilla DOM + fetch.
+(function() {
+	'use strict'
 
-$('#groups:not(:disabled)').change(_.debounce(function() {
-	$('#groups').attr('disabled', true).addClass('icon-loading');
-	var groups = $('#groups').val();
-	$.post(OC.linkToOCS('apps/preferred_providers/api/v1', 2)+ 'groups', {groups: groups}, function(response) {
-		$('#groups').attr('disabled', false).removeClass('icon-loading');
-	}, 'json');
-}, 250));
+	function ocsUrl(path) {
+		return OC.getRootPath() + '/ocs/v2.php/apps/preferred_providers/' + path
+	}
 
-$('#groups_unconfirmed:not(:disabled)').change(_.debounce(function() {
-	$('#groups_unconfirmed').attr('disabled', true).addClass('icon-loading');
-	var groups = $('#groups_unconfirmed').val();
-	$.post(OC.linkToOCS('apps/preferred_providers/api/v1', 2)+ 'groups', {groups: groups, for: 'unconfirmed'}, function(response) {
-		$('#groups_unconfirmed').attr('disabled', false).removeClass('icon-loading');
-	}, 'json');
-}, 250));
+	function ocs(path, options) {
+		return fetch(ocsUrl(path), Object.assign({
+			headers: {
+				'OCS-APIREQUEST': 'true',
+				requesttoken: OC.requestToken,
+				Accept: 'application/json',
+			},
+		}, options)).then(function(response) {
+			return response.json()
+		})
+	}
 
-$('#groups_confirmed:not(:disabled)').change(_.debounce(function() {
-	$('#groups_confirmed').attr('disabled', true).addClass('icon-loading');
-	var groups = $('#groups_confirmed').val();
-	$.post(OC.linkToOCS('apps/preferred_providers/api/v1', 2)+ 'groups', {groups: groups, for: 'confirmed'}, function(response) {
-		$('#groups_confirmed').attr('disabled', false).removeClass('icon-loading');
-	}, 'json');
-}, 250));
+	function debounce(fn, wait) {
+		var timer
+		return function() {
+			var context = this
+			var args = arguments
+			clearTimeout(timer)
+			timer = setTimeout(function() {
+				fn.apply(context, args)
+			}, wait)
+		}
+	}
+
+	function selectedValues(select) {
+		return Array.prototype.slice.call(select.selectedOptions).map(function(option) {
+			return option.value
+		})
+	}
+
+	function bindGroupSelect(id, forValue) {
+		var select = document.getElementById(id)
+		if (!select) {
+			return
+		}
+		select.addEventListener('change', debounce(function() {
+			select.disabled = true
+			select.classList.add('icon-loading')
+			var body = new URLSearchParams()
+			selectedValues(select).forEach(function(group) {
+				body.append('groups[]', group)
+			})
+			if (forValue) {
+				body.append('for', forValue)
+			}
+			ocs('api/v1/groups', { method: 'POST', body: body }).finally(function() {
+				select.disabled = false
+				select.classList.remove('icon-loading')
+			})
+		}, 250))
+	}
+
+	function init() {
+		var tokenField = document.getElementById('token')
+		var resetButton = document.getElementById('token-reset')
+		if (resetButton && tokenField) {
+			resetButton.addEventListener('click', debounce(function() {
+				resetButton.disabled = true
+				tokenField.classList.add('icon-loading')
+				ocs('api/v1/token/new').then(function(response) {
+					tokenField.value = response.ocs.data.token
+				}).finally(function() {
+					resetButton.disabled = false
+					tokenField.classList.remove('icon-loading')
+				})
+			}, 250))
+		}
+
+		bindGroupSelect('groups', '')
+		bindGroupSelect('groups_unconfirmed', 'unconfirmed')
+		bindGroupSelect('groups_confirmed', 'confirmed')
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', init)
+	} else {
+		init()
+	}
+})()

--- a/lib/Helper/ExpireUserTrait.php
+++ b/lib/Helper/ExpireUserTrait.php
@@ -32,7 +32,7 @@ trait ExpireUserTrait {
 		$user->setEnabled(false);
 		// flag the account as auto-disabled by this app, so it can be told apart
 		// from admin-disabled accounts and offered self-service reactivation
-		$this->config->setUserValue($userId, $this->appName, 'pp_disabled', '1');
+		$this->config->setUserValue($userId, Application::APP_ID, 'pp_disabled', '1');
 
 		// removing token to avoid conflict with further manual manipulation of the user
 		$this->config->deleteUserValue($userId, Application::APP_ID, 'disable_user_after');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1482 @@
+{
+	"name": "preferred_providers",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "preferred_providers",
+			"license": "AGPL-3.0-or-later",
+			"devDependencies": {
+				"@nextcloud/e2e-test-server": "^0.4.0",
+				"@playwright/test": "^1.61.1"
+			},
+			"engines": {
+				"node": "^24.0.0",
+				"npm": "^11.0.0"
+			}
+		},
+		"node_modules/@balena/dockerignore": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+			"integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@grpc/grpc-js": {
+			"version": "1.14.4",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+			"integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@grpc/proto-loader": "^0.8.0",
+				"@js-sdsl/ordered-map": "^4.4.2"
+			},
+			"engines": {
+				"node": ">=12.10.0"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+			"integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.5.5",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@grpc/proto-loader": {
+			"version": "0.7.15",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+			"integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.2.5",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@hapi/address": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+			"integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@hapi/hoek": "^11.0.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@hapi/formula": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+			"integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@hapi/hoek": {
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+			"integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@hapi/pinpoint": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+			"integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@hapi/tlds": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+			"integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@hapi/topo": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+			"integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@hapi/hoek": "^11.0.2"
+			}
+		},
+		"node_modules/@js-sdsl/ordered-map": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+			"integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/js-sdsl"
+			}
+		},
+		"node_modules/@nextcloud/e2e-test-server": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/e2e-test-server/-/e2e-test-server-0.4.0.tgz",
+			"integrity": "sha512-nKdLXOn4TY9+Z/dE4AKDsk6Fhp6xm5gUIFx4gW5z4Ivrp/nl7iGun5zDmbyjW7mHF55orqVxNl8GBHzVDTd0Sg==",
+			"dev": true,
+			"license": "AGPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/paths": "^2.2.1",
+				"dockerode": "^4.0.2",
+				"fast-xml-parser": "^5.2.2",
+				"wait-on": "^9.0.1"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/paths": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.4.0.tgz",
+			"integrity": "sha512-35hykjqzaJCw8pBYWuKbLLw2wyKMuf9+T8K8GoYiS84AIi8SO16nuEu0fyl/gwCuiDqX5tCCup4wqljf0hdvaw==",
+			"dev": true,
+			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nodable/entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+			"integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~8.3.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/anynum": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+			"integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/axios": {
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.16.0",
+				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/buildcheck": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+			"integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cpu-features": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+			"integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.19.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/docker-modem": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+			"integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"readable-stream": "^3.5.0",
+				"split-ca": "^1.0.1",
+				"ssh2": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
+		"node_modules/dockerode": {
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
+			"integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@balena/dockerignore": "^1.0.2",
+				"@grpc/grpc-js": "^1.11.1",
+				"@grpc/proto-loader": "^0.7.13",
+				"docker-modem": "^5.0.7",
+				"protobufjs": "^7.3.2",
+				"tar-fs": "^2.1.4",
+				"uuid": "^10.0.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+			"integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.2.0",
+				"fast-xml-builder": "^1.2.0",
+				"is-unsafe": "^1.0.1",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.4.1",
+				"xml-naming": "^0.1.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-unsafe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+			"integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/joi": {
+			"version": "18.2.3",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+			"integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@hapi/address": "^5.1.1",
+				"@hapi/formula": "^3.0.2",
+				"@hapi/hoek": "^11.0.7",
+				"@hapi/pinpoint": "^2.0.1",
+				"@hapi/tlds": "^1.1.1",
+				"@hapi/topo": "^6.0.2",
+				"@standard-schema/spec": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nan": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+			"integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+			"integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rxjs": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/split-ca": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+			"integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/ssh2": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+			"integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"asn1": "^0.2.6",
+				"bcrypt-pbkdf": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			},
+			"optionalDependencies": {
+				"cpu-features": "~0.0.10",
+				"nan": "^2.23.0"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+			"integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"anynum": "^1.0.1"
+			}
+		},
+		"node_modules/tar-fs": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+			"integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+			"dev": true,
+			"license": "Unlicense"
+		},
+		"node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/wait-on": {
+			"version": "9.0.10",
+			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.10.tgz",
+			"integrity": "sha512-rCoJEhvMr0X6alHmwc9abbrA5ZrLZFKpFQVKPNFwl2h7DapXOGdmimIHDtLOWhT4PjhZhxFEtZoQgEXbkDWdZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"axios": "^1.16.0",
+				"joi": "^18.2.1",
+				"lodash": "^4.18.1",
+				"minimist": "^1.2.8",
+				"rxjs": "^7.8.2"
+			},
+			"bin": {
+				"wait-on": "bin/wait-on"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "preferred_providers",
+	"description": "End-to-end tests for the Preferred Providers app",
+	"license": "AGPL-3.0-or-later",
+	"private": true,
+	"type": "module",
+	"engines": {
+		"node": "^24.0.0",
+		"npm": "^11.0.0"
+	},
+	"scripts": {
+		"start:nextcloud": "node playwright/start-nextcloud-server.mjs",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:report": "playwright show-report"
+	},
+	"devDependencies": {
+		"@nextcloud/e2e-test-server": "^0.4.0",
+		"@playwright/test": "^1.61.1"
+	}
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { defineConfig, devices } from '@playwright/test'
+
+const isCI = !!process.env.CI
+
+export default defineConfig({
+	testDir: './playwright/e2e',
+	timeout: 60000,
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1,
+	reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+
+	use: {
+		baseURL: process.env.BASE_URL ?? 'http://localhost:8089/index.php/',
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+	},
+
+	webServer: {
+		command: 'npm run start:nextcloud',
+		gracefulShutdown: { signal: 'SIGTERM', timeout: 15000 },
+		stderr: 'pipe',
+		stdout: 'pipe',
+		timeout: 6 * 60 * 1000,
+		// Readiness is the start script's explicit marker, printed only once the
+		// app is enabled AND fully provisioned. The port answers well before that,
+		// so a `url` check would race provisioning — hence stdout-based waiting.
+		wait: {
+			stdout: /preferred_providers Playwright environment is ready/,
+		},
+		// Locally (e.g. `--ui`) reuse a server that is already up so re-runs don't
+		// tear it down and restart it. In CI every run gets a fresh container.
+		...(isCI ? {} : { url: 'http://127.0.0.1:8089', reuseExistingServer: true }),
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+})

--- a/playwright/e2e/admin-settings.spec.ts
+++ b/playwright/e2e/admin-settings.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '@playwright/test'
+import { login } from '../support/login'
+import * as occ from '../support/occ'
+
+test('an admin can open the settings page and reset the provider token', async ({ page }) => {
+	await login(page, 'admin', 'admin')
+	await page.goto('settings/admin/preferred_providers')
+
+	// token + group sections render
+	const tokenField = page.locator('#token')
+	await expect(tokenField).toBeVisible()
+	const initialToken = await tokenField.inputValue()
+	expect(initialToken).not.toBe('')
+	await expect(page.locator('#groups')).toBeVisible()
+	await expect(page.locator('#groups_unconfirmed')).toBeVisible()
+	await expect(page.locator('#groups_confirmed')).toBeVisible()
+
+	try {
+		// the reset button (vanilla-JS OCS round-trip) issues a fresh token
+		await page.locator('#token-reset').click()
+		await expect(tokenField).not.toHaveValue(initialToken, { timeout: 10000 })
+		await expect(tokenField).not.toHaveValue('')
+	} finally {
+		// reset changed the shared token; restore it for the provisioning-dependent specs
+		await occ.setProviderToken()
+	}
+})

--- a/playwright/e2e/client-flows.spec.ts
+++ b/playwright/e2e/client-flows.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '@playwright/test'
+import { APP_ID } from '../support/constants.mjs'
+import * as occ from '../support/occ'
+import { requestAccount } from '../support/provider'
+
+/** The set-password token is the last path segment of the set-password URL. */
+function tokenFromUrl(setPasswordUrl: string): string {
+	const parts = new URL(setPasswordUrl).pathname.split('/').filter(Boolean)
+	return parts[parts.length - 1]
+}
+
+const PASSWORD = 'S3cr3t-e2e-pw!'
+
+test('client flow V3 renders the nc:// flow-login page', async ({ request }) => {
+	const { email, setPasswordUrl } = await requestAccount(request, 'e2e-v3')
+	const token = tokenFromUrl(setPasswordUrl)
+
+	const res = await request.post(`apps/${APP_ID}/password/submit/${token}`, {
+		form: { email, password: PASSWORD, flow: 'V3' },
+	})
+	expect(res.status()).toBe(200)
+	expect(await res.text()).toContain('nc://login')
+
+	await occ.deleteUser(email)
+})
+
+test('client flow with OCS-APIREQUEST redirects to the nc:// app-password URL', async ({ request }) => {
+	const { email, setPasswordUrl } = await requestAccount(request, 'e2e-ocs')
+	const token = tokenFromUrl(setPasswordUrl)
+
+	const res = await request.post(`apps/${APP_ID}/password/submit/${token}`, {
+		headers: { 'OCS-APIREQUEST': 'true' },
+		form: { email, password: PASSWORD, ocsapirequest: '1' },
+		maxRedirects: 0,
+	})
+	expect([301, 302, 303, 307, 308]).toContain(res.status())
+	expect(res.headers()['location'] ?? '').toMatch(/^nc:\/\/login\//)
+
+	await occ.deleteUser(email)
+})

--- a/playwright/e2e/reactivation.spec.ts
+++ b/playwright/e2e/reactivation.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { APP_ID } from '../support/constants.mjs'
+import { clearMailbox, extractLink, waitForMailBody } from '../support/mailpit'
+import * as occ from '../support/occ'
+import { requestAccount, toPath } from '../support/provider'
+
+async function submitReactivation(page: Page, email: string): Promise<void> {
+	await page.goto(`apps/${APP_ID}/reactivate`)
+	await expect(page.locator('#reactivate-form')).toBeVisible()
+	await page.locator('#email').fill(email)
+	await page.locator('#submit').click()
+	await expect(page.getByText('Check your email')).toBeVisible()
+}
+
+test('auto-disabled account can self-reactivate and re-verify', async ({ page, request }) => {
+	const { email } = await requestAccount(request, 'e2e-react')
+	await occ.seedAutoDisabled(email)
+	expect(await occ.isEnabled(email)).toBe(false)
+
+	await clearMailbox()
+	await submitReactivation(page, email)
+
+	// reactivation re-enabled the account and sent a fresh verification mail
+	expect(await occ.isEnabled(email)).toBe(true)
+	const confirmUrl = extractLink(await waitForMailBody(email), 'login/confirm')
+	await page.goto(toPath(confirmUrl))
+	expect(await occ.isEnabled(email)).toBe(true)
+
+	await occ.deleteUser(email)
+})
+
+test('admin-disabled account is NOT reactivatable via self-service', async ({ page, request }) => {
+	const { email } = await requestAccount(request, 'e2e-adminoff')
+	await occ.adminDisable(email) // no pp_disabled flag
+	expect(await occ.isEnabled(email)).toBe(false)
+
+	await clearMailbox()
+	await submitReactivation(page, email) // identical "sent" response (no enumeration)
+
+	// still disabled: the flow only touches accounts flagged pp_disabled=1
+	expect(await occ.isEnabled(email)).toBe(false)
+
+	await occ.deleteUser(email)
+})

--- a/playwright/e2e/signup.spec.ts
+++ b/playwright/e2e/signup.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '@playwright/test'
+import { GROUP_CONFIRMED, GROUP_UNCONFIRMED } from '../support/constants.mjs'
+import { expectLoggedIn } from '../support/login'
+import { clearMailbox, extractLink, waitForMailBody } from '../support/mailpit'
+import * as occ from '../support/occ'
+import { requestAccount, toPath } from '../support/provider'
+
+test('full signup → set password → login → verify email → group move', async ({ page, request }) => {
+	await clearMailbox()
+
+	// 1. provisioning API creates the account and hands back the set-password URL directly
+	const { email, setPasswordUrl } = await requestAccount(request, 'e2e-signup')
+	test.info().annotations.push({ type: 'account', description: email })
+	expect(await occ.inGroup(email, GROUP_UNCONFIRMED)).toBe(true)
+
+	// 2. set the password in the browser → auto-login + redirect home
+	await page.goto(toPath(setPasswordUrl))
+	await page.locator('#password').fill('S3cr3t-e2e-pw!')
+	await page.locator('#submit').click()
+	// submit redirects away from the set-password page and auto-logs the user in
+	await page.waitForURL((url) => !url.pathname.includes('/password/set'), { timeout: 30000 })
+	await expectLoggedIn(page, email)
+
+	// 3. the verification mail was sent on request → follow its confirm link
+	const body = await waitForMailBody(email)
+	const confirmUrl = extractLink(body, 'login/confirm')
+	await page.goto(toPath(confirmUrl))
+
+	// 4. verified: account enabled and moved from unconfirmed → confirmed group
+	expect(await occ.isEnabled(email)).toBe(true)
+	expect(await occ.inGroup(email, GROUP_CONFIRMED)).toBe(true)
+	expect(await occ.inGroup(email, GROUP_UNCONFIRMED)).toBe(false)
+
+	await occ.deleteUser(email)
+})

--- a/playwright/e2e/user-login.spec.ts
+++ b/playwright/e2e/user-login.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { test } from '@playwright/test'
+import { login } from '../support/login'
+import * as occ from '../support/occ'
+
+test('a user can log in through the web UI', async ({ page }) => {
+	const uid = `e2e-login-${Date.now()}`
+	await occ.createUser(uid, 'S3cr3t-e2e-pw!')
+
+	// login() asserts the session is established as this uid
+	await login(page, uid, 'S3cr3t-e2e-pw!')
+
+	await occ.deleteUser(uid)
+})

--- a/playwright/start-nextcloud-server.mjs
+++ b/playwright/start-nextcloud-server.mjs
@@ -1,0 +1,140 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+	configureNextcloud,
+	getContainerName,
+	runExec,
+	runOcc,
+	startNextcloud,
+	stopNextcloud,
+	waitOnNextcloud,
+} from '@nextcloud/e2e-test-server/docker'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import {
+	APP_ID,
+	GROUP_BASE,
+	GROUP_CONFIRMED,
+	GROUP_UNCONFIRMED,
+	MAILPIT_CONTAINER,
+	MAILPIT_IMAGE,
+	MAILPIT_NETWORK,
+	PROVIDER_TOKEN,
+} from './support/constants.mjs'
+
+/** Run a docker command, ignoring failures (e.g. "already exists"). */
+function quietExec(cmd) {
+	try {
+		execSync(cmd, { stdio: 'ignore' })
+	} catch {
+		// ignore
+	}
+}
+
+/** Resolve the server branch from env or the app's info.xml max-version. */
+function resolveBranch() {
+	if (process.env.SERVER_BRANCH) {
+		return process.env.SERVER_BRANCH
+	}
+	const appinfo = readFileSync('appinfo/info.xml').toString()
+	const maxVersion = appinfo.match(/max-version="(\d\d+)"/)?.[1]
+	if (maxVersion) {
+		try {
+			// Query only the candidate branch — a bare `git ls-remote` returns every
+			// ref (~1MB) and overflows execSync's default buffer (ENOBUFS).
+			const ref = execSync(
+				`git ls-remote --heads https://github.com/nextcloud/server.git stable${maxVersion}`,
+				{ encoding: 'utf-8' },
+			)
+			if (ref.includes(`refs/heads/stable${maxVersion}`)) {
+				return `stable${maxVersion}`
+			}
+		} catch {
+			// network/git failure → fall back to the minimum supported branch
+		}
+	}
+	return 'stable31'
+}
+
+/**
+ * Run Mailpit on a user-defined network shared with the server so the server can
+ * resolve it by name (the default bridge network has no container DNS), and
+ * publish the REST API on the host for the test process to poll.
+ */
+function startMailpit() {
+	quietExec(`docker network create ${MAILPIT_NETWORK}`)
+	quietExec(`docker network connect ${MAILPIT_NETWORK} ${getContainerName()}`)
+	quietExec(`docker rm -f ${MAILPIT_CONTAINER}`)
+	execSync(
+		`docker run -d --name ${MAILPIT_CONTAINER} --network ${MAILPIT_NETWORK} -p 8025:8025 ${MAILPIT_IMAGE}`,
+		{ stdio: 'inherit' },
+	)
+}
+
+async function configureMail() {
+	// Nextcloud reaches Mailpit by container name on the shared network (SMTP :1025);
+	// the test process reaches Mailpit's REST API on the host (:8025).
+	await runOcc(['config:system:set', 'mail_smtpmode', '--value', 'smtp'])
+	await runOcc(['config:system:set', 'mail_smtphost', '--value', MAILPIT_CONTAINER])
+	await runOcc(['config:system:set', 'mail_smtpport', '--value', '1025'])
+	await runOcc(['config:system:set', 'mail_from_address', '--value', 'no-reply'])
+	await runOcc(['config:system:set', 'mail_domain', '--value', 'example.com'])
+}
+
+async function provisionApp() {
+	// Ensure occ-written app config is visible to the web SAPI: with a local
+	// memcache, CLI and web caches diverge and Admin::getForm would see an empty
+	// provider_token and regenerate (clobbering) it.
+	await runOcc(['config:system:delete', 'memcache.local']).catch(() => {})
+
+	// groups used by the provider flow
+	for (const group of [GROUP_BASE, GROUP_UNCONFIRMED, GROUP_CONFIRMED]) {
+		await runOcc(['group:add', group]).catch(() => {})
+	}
+	await runOcc(['config:app:set', APP_ID, 'provider_token', `--value=${PROVIDER_TOKEN}`])
+	// provider_groups must be non-empty or the controller skips group assignment entirely
+	await runOcc(['config:app:set', APP_ID, 'provider_groups', `--value=${GROUP_BASE}`])
+	await runOcc(['config:app:set', APP_ID, 'provider_groups_unconfirmed', `--value=${GROUP_UNCONFIRMED}`])
+	await runOcc(['config:app:set', APP_ID, 'provider_groups_confirmed', `--value=${GROUP_CONFIRMED}`])
+
+	const seededToken = (await runOcc(['config:app:get', APP_ID, 'provider_token'])).trim()
+	process.stdout.write(`[provision] provider_token=${seededToken}\n`)
+
+	// Warm up routing/OCS/DB so the first real test doesn't hit a cold 500.
+	await runExec([
+		'curl', '-s', '-o', '/dev/null', '-X', 'POST', '-H', 'OCS-APIREQUEST: true',
+		`http://localhost/ocs/v2.php/account/request/${PROVIDER_TOKEN}?format=json&email=warmup@example.com`,
+	]).catch(() => {})
+}
+
+async function stop() {
+	process.stderr.write('Stopping Nextcloud server…\n')
+	quietExec(`docker rm -f ${MAILPIT_CONTAINER}`)
+	quietExec(`docker network rm ${MAILPIT_NETWORK}`)
+	await stopNextcloud()
+	// eslint-disable-next-line n/no-process-exit
+	process.exit(0)
+}
+
+process.on('SIGINT', stop)
+process.on('SIGTERM', stop)
+
+const branch = resolveBranch()
+const ip = await startNextcloud(branch, true, { exposePort: 8089, forceRecreate: true })
+await waitOnNextcloud(ip)
+await configureNextcloud([APP_ID], branch === 'master' ? 'master' : branch)
+
+startMailpit()
+await configureMail()
+await provisionApp()
+
+process.stdout.write('preferred_providers Playwright environment is ready\n')
+
+// Idle until Playwright signals shutdown.
+// eslint-disable-next-line no-constant-condition
+while (true) {
+	await new Promise((resolve) => setTimeout(resolve, 5000))
+}

--- a/playwright/support/constants.mjs
+++ b/playwright/support/constants.mjs
@@ -1,0 +1,27 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/** App id, as enabled in the test container. */
+export const APP_ID = 'preferred_providers'
+
+/** Provider token seeded into app config and used by the request-account API. */
+export const PROVIDER_TOKEN = 'e2e-provider-token'
+
+/**
+ * Base group every provisioned account is added to. Must be non-empty: the
+ * controller only runs its group assignment when provider_groups is set.
+ */
+export const GROUP_BASE = 'pp_all'
+/** Groups an unverified account is put into on request, then moved out of on verify. */
+export const GROUP_UNCONFIRMED = 'pp_pending'
+/** Groups an account is moved into once the email is verified. */
+export const GROUP_CONFIRMED = 'pp_members'
+
+/** Docker sidecar names / endpoints for capturing outgoing mail. */
+export const MAILPIT_CONTAINER = 'pp-mailpit'
+export const MAILPIT_IMAGE = 'axllent/mailpit:latest'
+/** User-defined network so the server can resolve Mailpit by name (bridge has no DNS). */
+export const MAILPIT_NETWORK = 'pp-e2e'
+export const MAILPIT_API = process.env.MAILPIT_API ?? 'http://localhost:8025'

--- a/playwright/support/login.ts
+++ b/playwright/support/login.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+/** Log in through the standard Nextcloud guest login form. */
+export async function login(page: Page, user: string, password: string): Promise<void> {
+	await page.goto('login')
+	await page.locator('input[name="user"]').fill(user)
+	await page.locator('input[name="password"]').fill(password)
+	await page.locator('button[type="submit"], input[type="submit"]').first().click()
+	await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 30000 })
+	await expectLoggedIn(page, user)
+}
+
+/** Assert the current session is logged in as the given uid. */
+export async function expectLoggedIn(page: Page, uid: string): Promise<void> {
+	const res = await page.request.get('/ocs/v2.php/cloud/user?format=json', {
+		headers: { 'OCS-APIREQUEST': 'true' },
+	})
+	expect(res.ok()).toBeTruthy()
+	const body = await res.json()
+	expect(body?.ocs?.data?.id).toBe(uid)
+}

--- a/playwright/support/mailpit.ts
+++ b/playwright/support/mailpit.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect } from '@playwright/test'
+import { MAILPIT_API } from './constants.mjs'
+
+interface MessageSummary {
+	ID: string
+	To: { Address: string }[]
+	Subject: string
+}
+
+/** Delete all captured messages — call before a step that expects a fresh mail. */
+export async function clearMailbox(): Promise<void> {
+	await fetch(`${MAILPIT_API}/api/v1/messages`, { method: 'DELETE' })
+}
+
+/** Poll until a message addressed to `recipient` arrives, then return its full text body. */
+export async function waitForMailBody(recipient: string): Promise<string> {
+	let lastError = 'no message'
+	for (let attempt = 0; attempt < 30; attempt++) {
+		const res = await fetch(`${MAILPIT_API}/api/v1/messages?query=${encodeURIComponent('to:' + recipient)}`)
+		if (res.ok) {
+			const list = (await res.json()) as { messages: MessageSummary[] }
+			const match = list.messages?.find((m) => m.To?.some((t) => t.Address === recipient))
+			if (match) {
+				const full = await fetch(`${MAILPIT_API}/api/v1/message/${match.ID}`)
+				const body = (await full.json()) as { Text: string, HTML: string }
+				return body.Text || body.HTML || ''
+			}
+			lastError = `no message to ${recipient} yet`
+		} else {
+			lastError = `mailpit ${res.status}`
+		}
+		await new Promise((r) => setTimeout(r, 1000))
+	}
+	throw new Error(`Timed out waiting for mail to ${recipient}: ${lastError}`)
+}
+
+/** Extract the first absolute URL whose path matches `pathFragment`. */
+export function extractLink(body: string, pathFragment: string): string {
+	// mail templates may percent/entity-encode; normalise the common cases
+	const normalised = body.replace(/&amp;/g, '&').replace(/=\r?\n/g, '')
+	const re = new RegExp(`https?://[^\\s"'<>]*${pathFragment}[^\\s"'<>]*`)
+	const match = normalised.match(re)
+	expect(match, `expected a ${pathFragment} link in the email body`).not.toBeNull()
+	return match![0]
+}

--- a/playwright/support/occ.ts
+++ b/playwright/support/occ.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// @ts-expect-error - the harness ships CJS without bundled types for this entrypoint
+import { runOcc } from '@nextcloud/e2e-test-server/docker'
+import { APP_ID, PROVIDER_TOKEN } from './constants.mjs'
+
+interface UserInfo {
+	user_id: string
+	email: string | null
+	enabled: boolean
+	groups: string[]
+}
+
+/** Create an enabled user with a known password (via OC_PASS). */
+export async function createUser(uid: string, password: string): Promise<void> {
+	await runOcc(['user:add', '--password-from-env', uid], { env: [`OC_PASS=${password}`] })
+}
+
+/** Restore the shared provider token (undoes an admin-page token regeneration). */
+export async function setProviderToken(token: string = PROVIDER_TOKEN): Promise<void> {
+	await runOcc(['config:app:set', APP_ID, 'provider_token', `--value=${token}`])
+}
+
+export async function userInfo(uid: string): Promise<UserInfo> {
+	const out = await runOcc(['user:info', uid, '--output=json'])
+	return JSON.parse(out) as UserInfo
+}
+
+export async function isEnabled(uid: string): Promise<boolean> {
+	return (await userInfo(uid)).enabled
+}
+
+export async function inGroup(uid: string, group: string): Promise<boolean> {
+	return (await userInfo(uid)).groups.includes(group)
+}
+
+/** Force an account into the "auto-disabled by this app" state, no 6h wait. */
+export async function seedAutoDisabled(uid: string): Promise<void> {
+	await runOcc(['user:disable', uid])
+	// user preferences are managed via `user:setting <uid> <app> <key> <value>`
+	await runOcc(['user:setting', uid, APP_ID, 'pp_disabled', '1'])
+}
+
+/** Disable an account the way an admin would (no pp_disabled flag). */
+export async function adminDisable(uid: string): Promise<void> {
+	await runOcc(['user:disable', uid])
+}
+
+export async function deleteUser(uid: string): Promise<void> {
+	await runOcc(['user:delete', uid]).catch(() => {})
+}

--- a/playwright/support/provider.ts
+++ b/playwright/support/provider.ts
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { APIRequestContext } from '@playwright/test'
+import { expect } from '@playwright/test'
+import { PROVIDER_TOKEN } from './constants.mjs'
+
+/**
+ * Reduce an absolute Nextcloud URL to an origin-relative path so navigation
+ * always goes through the Playwright baseURL host, regardless of the
+ * overwrite.cli.url the container reports.
+ */
+export function toPath(absolute: string): string {
+	const url = new URL(absolute)
+	return url.pathname + url.search
+}
+
+export interface RequestedAccount {
+	email: string
+	setPasswordUrl: string
+}
+
+/**
+ * Call the public OCS request-account endpoint for a freshly generated address
+ * and return that address plus the set-password URL it hands back directly.
+ *
+ * A transient 5xx (cold server / sqlite lock) can still create the user before
+ * failing, so each retry uses a brand-new address rather than colliding on
+ * "user already exists".
+ */
+export async function requestAccount(request: APIRequestContext, prefix = 'e2e'): Promise<RequestedAccount> {
+	let lastText = ''
+	for (let attempt = 0; attempt < 4; attempt++) {
+		const email = `${prefix}-${Date.now()}-${attempt}@example.com`
+		// OCS is served from the origin (…/ocs/v2.php), not under the /index.php/ baseURL.
+		// The route declares root '/account', replacing the default /apps/{appid} prefix.
+		const res = await request.post(
+			`/ocs/v2.php/account/request/${PROVIDER_TOKEN}?format=json`,
+			{
+				headers: { 'OCS-APIREQUEST': 'true' },
+				form: { email },
+			},
+		)
+		if (res.status() >= 500) {
+			lastText = await res.text()
+			await new Promise((r) => setTimeout(r, 1000))
+			continue
+		}
+		expect(res.status(), await res.text()).toBe(201)
+		const body = await res.json()
+		// AccountController is an ApiController → the DataResponse is returned as
+		// plain JSON ({"data":{"setPassword":…}}), not wrapped in the OCS envelope.
+		const setPasswordUrl = body?.data?.setPassword ?? body?.ocs?.data?.data?.setPassword
+		expect(setPasswordUrl, `no setPassword URL in response: ${JSON.stringify(body)}`).toBeTruthy()
+		return { email, setPasswordUrl: setPasswordUrl as string }
+	}
+	throw new Error(`request-account kept failing with 5xx: ${lastText}`)
+}


### PR DESCRIPTION

## Scenarios covered

- **Account signup (happy path)** — request an account via the OCS API → open the returned set-password page → set a password → auto-login → follow the emailed verification link → account is enabled and moved from the unconfirmed group to the confirmed group.
- **Client flow (V3)** — submitting the password with `flow=V3` renders the `nc://` flow-login page for desktop/mobile clients.
- **Client flow (OCS-APIREQUEST)** — submitting with the OCS client header redirects to the `nc://login/…` app-password URL.
- **Self-service reactivation** — an account auto-disabled by the app (`pp_disabled`) reactivates itself through the public `/reactivate` form, receives a fresh verification mail, and re-verifies.
- **Reactivation guard** — an account disabled by an admin (no `pp_disabled` flag) is NOT reactivatable through the self-service form (identical response, stays disabled — no enumeration).
- **User login** — a user can log in through the standard web UI.
- **Admin settings access** — an admin can open the app's admin settings page (token + group sections render).



## Also included

- **`fix(settings)`**: `admin-settings.js` rewritten dependency-free (jQuery / underscore / `OC.linkToOCS` are gone from the modern server bundle, so the reset-token button and group selectors were dead on NC 32+). The admin scenario now exercises the reset round-trip end-to-end.

---
This PR was developed with AI assistance (Claude Code, `claude-opus-4-8`); the commit carries an `Assisted-by:` trailer. I have reviewed and run the suite and take authorship of it.

