### PR TITLE
release: 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this app are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 2.0.0
+
+Major release modernizing the app to current Nextcloud standards.
+
+> **Breaking:** requires **Nextcloud 31+** and **PHP 8.1+**. Older Nextcloud and
+> PHP versions are no longer supported.
+
+### Added
+- Self-service account reactivation: users auto-disabled for missing the
+  email-verification window can recover their account without an admin (#154, closes #5).
+- Support for the V3 login flow in the registration process (#151).
+- PHPUnit unit-test suite with a sqlite/mysql/pgsql CI matrix (#159).
+- Playwright end-to-end suite covering the full account lifecycle (#162).
+- Nextcloud 33, 34 and 35 support (#138, #139, #153).
+
+### Changed
+- Modernized the PHP codebase: attribute-based routing and controllers,
+  constructor property promotion, SPDX/REUSE headers, and psalm + php-cs-fixer
+  + rector wired through composer-bin (#158, #161).
+- Migrated app configuration to the typed `IAppConfig` API (#158).
+- Rewrote `admin-settings.js` dependency-free so it works on Nextcloud 32+,
+  where jQuery, underscore and `OC.linkToOCS` were dropped (#162).
+- Updated CI actions and dev dependencies (#140–#148, #156, #157).
+
+### Fixed
+- The `ExpireUnverifiedAccounts` background job no longer crashes when expiring
+  an account (missing `IUserManager` injection, and an undefined-property
+  regression in the `pp_disabled` write) (#159, #162).
+- Corrected the README link to the second repository (#149) and a company-name
+  typo (#150).
+- Fixed capitalization in the summary tag translation (#160).

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -19,6 +19,7 @@ path = [
 	".php-cs-fixer.dist.php",
 	"Makefile",
 	"README.md",
+	"CHANGELOG.md",
 	"appinfo/info.xml",
 	"composer.json",
 	"composer.lock",

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>Preferred Providers</name>
     <summary>Allow Nextcloud to request user accounts</summary>
     <description><![CDATA[Registration handling app for Nextcloud partners only]]></description>
-    <version>1.20.0-dev.0</version>
+    <version>2.0.0</version>
     <licence>agpl</licence>
     <author>John Molakvoæ</author>
     <namespace>Preferred_Providers</namespace>


### PR DESCRIPTION
## Preferred Providers 2.0.0

Major release modernizing the app to current Nextcloud standards. **Requires Nextcloud 31+ and PHP 8.1+** — older Nextcloud/PHP versions are no longer supported (breaking change).

### ✨ Features
- **Self-service account reactivation** — users auto-disabled for missing the email-verification window can now recover their account without contacting an admin (#154, closes #5)
- Support the **V3 login flow** in the registration process (#151)

### ♻️ Refactor & modernization
- Modernized PHP codebase: **attribute-based routing & controllers**, constructor property promotion, SPDX/REUSE headers, and psalm + php-cs-fixer + rector wired via `composer-bin` (#158, #161)
- Migrated app config to the typed `IAppConfig` API (#158)
- Rewrote `admin-settings.js` dependency-free so it works on NC 32+ (jQuery/underscore/`OC.linkToOCS` were dropped) (#162)

### 🐛 Bug fixes
- Fixed the `ExpireUnverifiedAccounts` background job crashing when expiring an account (missing `IUserManager` injection; undefined-property regression in the `pp_disabled` write) (#159, #162)
- README link to the second repo (#149) and a company-name typo (#150)
- i18n capitalization in the summary tag (#160)

### ✅ Testing
- Full **PHPUnit** unit-test suite with a sqlite/mysql/pgsql CI matrix (#159)
- **Playwright** end-to-end suite covering the whole account lifecycle (#162)

### 🧩 Nextcloud compatibility
- Added support for Nextcloud 33, 34 and 35 (#138, #139, #153)

### ⬆️ Dependencies
- Bumped CI actions and dev dependencies via Dependabot — `setup-php`, `actions/checkout`, `actions/setup-node`, `phpunit`, `nextcloud-version-matrix`, and others (#140–#148, #156, #157)

---

This release PR bumps `appinfo/info.xml` to `2.0.0` and adds `CHANGELOG.md`. After merge, the tag / GitHub release / appstore publish is done by a maintainer.

_AI-assisted (Claude Code, `claude-opus-4-8`); the commit carries an `Assisted-by:` trailer. Reviewed and owned by the submitter._
